### PR TITLE
Modified document to use dtls-association-id instead of dtls-connection

### DIFF
--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -445,7 +445,7 @@
             <t>
                 Unless explicitly prohibited by underlying transport DTLS association 
                 can span across transport changes. If fingerprints, SDP 'dtls-association-id',
-                and negotiated role remain the same, exisitng DTLS association continues
+                and negotiated role remain the same, existing DTLS association continues
                 even if underlying transport 5-tuple changes or ICE session is restarted.
             </t>
         </section>
@@ -462,7 +462,7 @@
         </t>
         <t>
             It is possible to send an INVITE request which does not contain an SDP offer. Such
-            INVITE request is often referred to as an 'empty INVITE', or an 'offerless INVITE'.
+            INVITE request is often referred to as an 'empty INVITE', or an 'offer-less INVITE'.
             The receiving endpoint will include the SDP offer in a response associated with the
             response. When the endpoint generates such SDP offer, if a previously established
             DTLS association exists, the offerer SHOULD insert the SDP 'dtls-association-id' 
@@ -653,7 +653,7 @@
         </figure>
     </section>
 
-    <section title="Acknowledgements">
+    <section title="Acknowledgments">
         <t>
             Thanks to Justin Uberti, Martin Thomson, Paul Kyzivat, Jens Guballa,
             Charles Eckel and Gonzalo Salgueiro for providing comments and

--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -259,11 +259,19 @@
                 value associated with the DTLS association. The use of SHA-256 is preferred.
             </t>
             <t>
-                The certificate received during the DTLS handshake MUST match one of the fingerprints
-                received in an SDP "fingerprint" attributes. If none of the fingerprints match the 
-                received certificate, then the endpoint MUST tear down the media session immediately.
-                Note that it is permissible to wait until the other side's fingerprints have been received
-                before establishing the connection; however, this may have undesirable latency effects.
+                Endpoints MUST, at a minimum, support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 
+				and MUST support TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256. UDPTL over DTLS MUST 
+				prefer TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and any other Perfect Forward Secrecy 
+				(PFS) cipher suites over non-PFS cipher suites. Implementations SHOULD disable 
+				TLS-level compression.
+			</t>
+			<t>
+				The certificate received during the DTLS handshake MUST match 
+				a fingerprint received in an SDP "fingerprint" attribute. If a fingerprint 
+				does not match the hashed certificate, then the endpoint MUST tear down the media 
+				session immediately. Note that it is permissible to wait until the other side's 
+				fingerprint has been received before establishing the connection; however, this 
+				may have undesirable latency effects.
             </t>
         </section>
 
@@ -282,18 +290,13 @@
                 least 128 bits of randomness, which means an alphanumeric string at least 25 characters long.
             </t>
             <t>
-                In addition, the offerer MUST insert an SDP 'setup' attribute set to 'actpass' and one or more SDP
-                'fingerprint' attributes according to the procedures in <xref format="default" pageno="false" target="RFC4572"/>,
-                in the offer.
+                In addition, the offerer MUST insert an SDP 'setup' attribute according to the procedures in <xref format="default"
+                pageno="false" target="RFC4145"/> and one or more SDP 'fingerprint' attributes according to the procedures in <xref
+                format="default" pageno="false" target="RFC4572"/>, in the offer.
             </t>
             <t>
-                Offerer MUST allocate a new transport for the offer in such a way that it can disambiguate any packets
-                associated with newly established DTLS association from any packets associated with any other DTLS
-                association. This typically means using a local address and or port, or a set of ICE candidates, 
-                if ICE is used, which were not recently used for any other DTLS association.
-            </t>
-            <t>
-                The offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
+                If the offerer inserts the SDP 'setup' attribute with an 'actpass' or 'passive' value, the 
+                offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
                 is established by the answerer) from the answerer before it receives the SDP answer.
             </t>
         </section>
@@ -318,13 +321,6 @@
                 attribute is to use a random alphanumeric string of sufficient length. If such random string is used 
                 for the SDP 'dtls-association-id' attribute, in order to avoid collisions, it is recommended to use at
                 least 128 bits of randomness, which means an alphanumeric string at least 25 characters long.
-            </t>
-            <t>
-                Furthermore, if answerer needs to establish a new DTLS association, it MUST allocate a new transport
-                for the offer in answer a way that it can disambiguate any packets associated with newly established 
-                DTLS association from any packets associated with any other DTLS association. This typically means
-                using a local address and or port, or a set of ICE candidates, if ICE is used, which were not recently
-                used for any other DTLS association.
             </t>
             <t>
                 In addition, the answerer MUST insert an SDP 'setup' attribute according
@@ -378,18 +374,17 @@
                 When the offerer sends a subsequent offer, and if the offerer wants to establish a new
                 DTLS association, the offerer MUST guarantee that combination of fingerprint values and 
                 the SDP 'dtls-association-id' attribute value is unique across all the DTLS associations.
-                In addition, the offerer MUST insert an SDP 'setup' attribute set to 'actpass', and one or more
-                SDP 'fingerprint' attributes according to the procedures in <xref format="default" pageno="false"
-                target="RFC4572"/>, in the offer. Furthermore, offerer MUST allocate a new transport for the offer
-                in such a way that it can disambiguate any packets associated with newly established DTLS association
-                from any packets associated with any other DTLS association.
+                In addition, the offerer MUST insert an SDP 'setup' attribute  according to the procedures
+                in <xref format="default" pageno="false" target="RFC4145"/>, and one or more SDP
+                'fingerprint' attributes according to the procedures in <xref format="default" pageno="false"
+                target="RFC4572"/>, in the offer.
             </t>
              <t>
                 When the offerer sends a subsequent offer, and the offerer does not want to establish
                 a new DTLS association, and if a previously established DTLS association exists, the
                 offerer MUST insert the SDP 'dtls-association-id' attribute and fingerprint values
-                set to the same values as previously sent values for these attributes, and the SDP 'setup'
-                attribute set to the previously negotiated role for this DTLS association, in the offer.
+                set to the same values as previously sent values for these attributes, an SDP 'setup' attribute with a value that does 
+                not change the previously negotiated DTLS roles, in the offer.
             </t>
             <t>
                 NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive
@@ -416,37 +411,15 @@
             a change of local transport parameters when an endpoint switches between those
             ICE candidates.
         </t>
-        <t>
-            When new DTLS association is established, in order to disambiguate any packets
-            associated with newly established DTLS association, at least one of the end
-            points MUST allocate a completely new set of ICE candidates which were not recently
-            used for any other DTLS association. This also means that answerer cannot
-            initiate a new DTLS association unless offerer initiated ICE restart.
-        </t>
-        <t>
-            Note that Simple Traversal of the UDP Protocol through NAT (STUN)
-            packets are sent directly over UDP, not over DTLS.  [RFC5764]
-            describes how to demultiplex STUN packets from DTLS packets and SRTP
-            packets.
-        </t>
     </section>
 
     <section title="Transport Protocol Considerations" anchor="sec-dtls-cons-trans">
         <section title="Transport Re-Usage" anchor="sec-dtls-cons-trans-reuse">
             <t>
-                If DTLS is transported on top of a reliable transport protocol (e.g. TCP or SCTP),
-                where all IP packets are acknowledged, multiple DTLS associations can
-                reuse the same transport protocol. All DTLS packets associated with a previous
+                If DTLS is transported on top of a connection-oriented transport protocol (e.g. TCP or SCTP),
+                where all IP packets are acknowledged, all DTLS packets associated with a previous
                 DTLS association MUST be acknowledged (or timed out) before a new DTLS association
                 can be established on the same transport.
-            </t>
-        </section>
-        <section title="Spanning Multiple Transport" anchor="sec-dtls-cons-trans-span">
-            <t>
-                Unless explicitly prohibited by underlying transport DTLS association 
-                can span across transport changes. If fingerprints, SDP 'dtls-association-id',
-                and negotiated role remain the same, existing DTLS association continues
-                even if underlying transport 5-tuple changes or ICE session is restarted.
             </t>
         </section>
     </section>
@@ -470,7 +443,8 @@
             for these attributes. If a previously established DTLS association did not exists 
             offer SHOULD be generated based on the same rules as new offer <xref target="sec-oa-offer"/>.
             Regardless of the previous existence of DTLS association, the SDP 'setup' attribute 
-            MUST be set to 'actpass' and if ICE is used, ICE restart MUST be initiated as defined in
+            MUST be included according to rules defiend in <xref format="default" pageno="false" 
+            target="RFC4145"/> and if ICE is used, ICE restart MUST be initiated as defined in
             <xref format="default" pageno="false" target="RFC5763"/>.
         </t>
     </section>
@@ -484,40 +458,44 @@
             </t>
         </section>
         <section title="Update to RFC 5763">
-            <section title="Update to Section 5. Establishing a Secure Channel">
-                <t>
-                    This section is updated to clarify the procedure for matching multiple fingerprints
-                    and to modify the offer/answer procedures based on the rules provided in this specification.
-                </t>
-                <t>
+            <figure>
+                <artwork align="left" alt="" height="" name="" type="" width="" xml:space="preserve"><![CDATA[
+
+Update to section 5:
+--------------------                
+
+OLD TEXT:
+
+5.  Establishing a Secure Channel
                    The two endpoints in the exchange present their identities as part of
                    the DTLS handshake procedure using certificates.  This document uses
                    certificates in the same style as described in "Connection-Oriented
                    Media Transport over the Transport Layer Security (TLS) Protocol in
                    the Session Description Protocol (SDP)" [RFC4572].
-                </t>
-                <t>
+
                    If self-signed certificates are used, the content of the
                    subjectAltName attribute inside the certificate MAY use the uniform
                    resource identifier (URI) of the user.  This is useful for debugging
                    purposes only and is not required to bind the certificate to one of
                    the communication endpoints.  The integrity of the certificate is
-                   ensured through the fingerprint attribute in the SDP.
-                </t>
-                <t>
+   ensured through the fingerprint attribute in the SDP.  The
+   subjectAltName is not an important component of the certificate
+   verification.
+
                    The generation of public/private key pairs is relatively expensive.
                    Endpoints are not required to generate certificates for each session.
-                </t>
-                <t>
+
                    The offer/answer model, defined in [RFC3264], is used by protocols
                    like the Session Initiation Protocol (SIP) [RFC3261] to set up
-                   multimedia sessions.
-                </t>
-                <t>
+   multimedia sessions.  In addition to the usual contents of an SDP
+   [RFC4566] message, each media description ("m=" line and associated
+   parameters) will also contain several attributes as specified in
+   [RFC5764], [RFC4145], and [RFC4572].
+
                    When an endpoint wishes to set up a secure media session with another
                    endpoint, it sends an offer in a SIP message to the other endpoint.
-                   This offer includes, as part of the SDP payload, a set fingerprints for
-                   for one or more certificate that the endpoint can use.  The endpoint SHOULD
+   This offer includes, as part of the SDP payload, the fingerprint of
+   the certificate that the endpoint wants to use.  The endpoint SHOULD
                    send the SIP message containing the offer to the offerer's SIP proxy
                    over an integrity protected channel.  The proxy SHOULD add an
                    Identity header field according to the procedures outlined in
@@ -529,99 +507,346 @@
                    in addition to the body of the SIP message, the receiver can also be
                    certain that the message has not been tampered with after the digital
                    signature was applied and added to the SIP message.
-                </t>
-                <t>
-                   The far endpoint (answerer) may now establish a DTLS association with
-                   the offerer.  Alternately, it can indicate in its answer that the
-                   offerer is to initiate the DTLS association.  In either case, mutual
-                   DTLS certificate-based authentication will be used.  After completing
-                   the DTLS handshake, information about the authenticated identities,
-                   including the certificates, are made available to the endpoint
-                   application.  The answerer is then able to verify that the offerer's
-                   certificate used for authentication in the DTLS handshake can be
-                   associated to any of the certificate fingerprints contained in the offer in
-                   the SDP.  At this point, the answerer may indicate to the end user
-                   that the media is secured.  The offerer may only tentatively accept
-                   the answerer's certificate since it may not yet have the fingerprints
-                   for answerer certificates.
-                </t>
-                <t>
-                   When the answerer accepts the offer, it provides an answer back to
-                   the offerer containing fingerprints the answerer's certificates.  At
-                   this point, the offerer can accept or reject the peer's certificate
-                   and the offerer can indicate to the end user that the media is
-                   secured.
-                </t>
-                <t>
-                   Note that the entire authentication and key exchange for securing the
-                   media traffic is handled in the media path through DTLS.  The
-                   signaling path is only used to verify the peers' certificate
-                   fingerprints.
-                </t>
-                <t>
-                   The offerer and answerer MUST follow the SDP offer/answer procedures
-                   defined in [RFCXXXX].
-                </t>
-            </section>
-            <section title="Update to Section 6.6. Session Modification">
-                <t>
-                    This section is updated to use offer/answer procedures based on the rules provided
-                    in this specification.
-                </t>
-                <t>
-                   Once an answer is provided to the offerer, either endpoint MAY
-                   request a session modification that MAY include an updated offer.
-                   This session modification can be carried in either an INVITE or
-                   UPDATE request. The peers can reuse an existing DTLS association,
-                   or establish a new one, following the procedures in [RFCXXXX].
-                </t>
-            </section>
-            <section title="Update to Section 6.7.1. ICE Interaction">
-                <t>
-                    This section is updated to use ICE related rules provided
-                    in this specification.
-                </t>
-                <t>
-                   The Interactive Connectivity Establishment (ICE) [RFC5245]
-                   considerations for DTLS-protected media are described in
-                   [RFCXXXX].
-                </t>
-            </section>
+
+   The far endpoint (answerer) may now establish a DTLS association with
+   the offerer.  Alternately, it can indicate in its answer that the
+   offerer is to initiate the TLS association.  In either case, mutual
+   DTLS certificate-based authentication will be used.  After completing
+   the DTLS handshake, information about the authenticated identities,
+   including the certificates, are made available to the endpoint
+   application.  The answerer is then able to verify that the offerer's
+   certificate used for authentication in the DTLS handshake can be
+   associated to the certificate fingerprint contained in the offer in
+   the SDP.  At this point, the answerer may indicate to the end user
+   that the media is secured.  The offerer may only tentatively accept
+   the answerer's certificate since it may not yet have the answerer's
+   certificate fingerprint.
+
+   When the answerer accepts the offer, it provides an answer back to
+   the offerer containing the answerer's certificate fingerprint.  At
+   this point, the offerer can accept or reject the peer's certificate
+   and the offerer can indicate to the end user that the media is
+   secured.
+   Note that the entire authentication and key exchange for securing the
+   media traffic is handled in the media path through DTLS.  The
+   signaling path is only used to verify the peers' certificate
+   fingerprints.
+   The offer and answer MUST conform to the following requirements.
+   o  The endpoint MUST use the setup attribute defined in [RFC4145].
+      The endpoint that is the offerer MUST use the setup attribute
+      value of setup:actpass and be prepared to receive a client_hello
+      before it receives the answer.  The answerer MUST use either a
+      setup attribute value of setup:active or setup:passive.  Note that
+      if the answerer uses setup:passive, then the DTLS handshake will
+      not begin until the answerer is received, which adds additional
+      latency. setup:active allows the answer and the DTLS handshake to
+      occur in parallel.  Thus, setup:active is RECOMMENDED.  Whichever
+      party is active MUST initiate a DTLS handshake by sending a
+      ClientHello over each flow (host/port quartet).
+   o  The endpoint MUST NOT use the connection attribute defined in
+      [RFC4145].
+   o  The endpoint MUST use the certificate fingerprint attribute as
+      specified in [RFC4572].
+   o  The certificate presented during the DTLS handshake MUST match the
+      fingerprint exchanged via the signaling path in the SDP.  The
+      security properties of this mechanism are described in Section 8.
+   o  If the fingerprint does not match the hashed certificate, then the
+      endpoint MUST tear down the media session immediately.  Note that
+      it is permissible to wait until the other side's fingerprint has
+      been received before establishing the connection; however, this
+      may have undesirable latency effects.
+NEW TEXT:
+5.  Establishing a Secure Channel
+   The two endpoints in the exchange present their identities as part of
+   the DTLS handshake procedure using certificates.  This document uses
+   certificates in the same style as described in "Connection-Oriented
+   Media Transport over the Transport Layer Security (TLS) Protocol in
+   the Session Description Protocol (SDP)" [RFC4572].
+   If self-signed certificates are used, the content of the
+   subjectAltName attribute inside the certificate MAY use the uniform
+   resource identifier (URI) of the user.  This is useful for debugging
+   purposes only and is not required to bind the certificate to one of
+   the communication endpoints.  The integrity of the certificate is
+   ensured through the fingerprint attribute in the SDP.
+
+   The generation of public/private key pairs is relatively expensive.
+   Endpoints are not required to generate certificates for each session.
+
+   The offer/answer model, defined in [RFC3264], is used by protocols
+   like the Session Initiation Protocol (SIP) [RFC3261] to set up
+   multimedia sessions.
+   
+   When an endpoint wishes to set up a secure media session with another
+   endpoint, it sends an offer in a SIP message to the other endpoint.
+   This offer includes, as part of the SDP payload, a fingerprint of
+   a certificate that the endpoint wants to use.  The endpoint SHOULD
+   send the SIP message containing the offer to the offerer's SIP proxy
+   over an integrity protected channel.  The proxy SHOULD add an
+   Identity header field according to the procedures outlined in
+   [RFC4474].  The SIP message containing the offer SHOULD be sent to
+   the offerer's SIP proxy over an integrity protected channel.  When
+   the far endpoint receives the SIP message, it can verify the identity
+   of the sender using the Identity header field.  Since the Identity
+   header field is a digital signature across several SIP header fields,
+   in addition to the body of the SIP message, the receiver can also be
+   certain that the message has not been tampered with after the digital
+   signature was applied and added to the SIP message.
+
+   The far endpoint (answerer) may now establish a DTLS association with
+   the offerer.  Alternately, it can indicate in its answer that the
+   offerer is to initiate the DTLS association.  In either case, mutual
+   DTLS certificate-based authentication will be used.  After completing
+   the DTLS handshake, information about the authenticated identities,
+   including the certificates, are made available to the endpoint
+   application.  The answerer is then able to verify that the offerer's
+   certificate used for authentication in the DTLS handshake can be
+   associated to the certificate fingerprint contained in the offer in
+   the SDP.  At this point, the answerer may indicate to the end user
+   that the media is secured.  The offerer may only tentatively accept
+   the answerer's certificate since it may not yet have the answerer's
+   certificate fingerprint.
+
+   When the answerer accepts the offer, it provides an answer back to
+   the offerer containing the answerer's certificate fingerprint.  At
+   this point, the offerer can accept or reject the peer's certificate
+   and the offerer can indicate to the end user that the media is
+   secured.
+
+   Note that the entire authentication and key exchange for securing the
+   media traffic is handled in the media path through DTLS.  The
+   signaling path is only used to verify the peers' certificate
+   fingerprints.
+
+   The offerer and answerer MUST follow the SDP offer/answer procedures 
+   defined in [RFCXXXX].
+   
+      
+Update to section 6.6:
+----------------------
+
+OLD TEXT:
+
+6.6.  Session Modification
+
+   Once an answer is provided to the offerer, either endpoint MAY
+   request a session modification that MAY include an updated offer.
+   This session modification can be carried in either an INVITE or
+   UPDATE request.  The peers can reuse the existing associations if
+   they are compatible (i.e., they have the same key fingerprints and
+   transport parameters), or establish a new one following the same
+   rules are for initial exchanges, tearing down the existing
+   association as soon as the offer/answer exchange is completed.  Note
+   that if the active/passive status of the endpoints changes, a new
+   connection MUST be established.
+ 
+NEW TEXT:
+
+6.6.  Session Modification
+
+   Once an answer is provided to the offerer, either endpoint MAY
+   request a session modification that MAY include an updated offer.
+   This session modification can be carried in either an INVITE or
+   UPDATE request. The peers can reuse an existing DTLS association, 
+   or establish a new one, following the procedures in [RFCXXXX].
+
+Update to section 6.7.1:
+------------------------
+
+OLD TEXT:
+
+6.7.1.  ICE Interaction
+
+   Interactive Connectivity Establishment (ICE), as specified in
+   [RFC5245], provides a methodology of allowing participants in
+   multimedia sessions to verify mutual connectivity.  When ICE is being
+   used, the ICE connectivity checks are performed before the DTLS
+   handshake begins.  Note that if aggressive nomination mode is used,
+   multiple candidate pairs may be marked valid before ICE finally
+   converges on a single candidate pair.  Implementations MUST treat all
+   ICE candidate pairs associated with a single component as part of the
+   same DTLS association.  Thus, there will be only one DTLS handshake
+   even if there are multiple valid candidate pairs.  Note that this may
+   mean adjusting the endpoint IP addresses if the selected candidate
+   pair shifts, just as if the DTLS packets were an ordinary media
+   stream.
+
+   Note that Simple Traversal of the UDP Protocol through NAT (STUN)
+   packets are sent directly over UDP, not over DTLS.  [RFC5764]
+   describes how to demultiplex STUN packets from DTLS packets and SRTP
+   packets.
+
+NEW TEXT:
+
+6.7.1.  ICE Interaction
+
+   The Interactive Connectivity Establishment (ICE) [RFC5245]
+   considerations for DTLS-protected media are described in
+   [RFCXXXX].
+
+   Note that Simple Traversal of the UDP Protocol through NAT (STUN)
+   packets are sent directly over UDP, not over DTLS.  [RFC5764]
+   describes how to demultiplex STUN packets from DTLS packets and SRTP
+   packets.
+   
+                ]]></artwork>
+            </figure>
         </section>
         <section title="Update to RFC 7345">
-            <section title="Update to Section 4. SDP Offerer/Answerer Procedures">
-                <t>
-                    This section is updated to use offer/answer rules provided
-                    in this specification.
-                </t>
-                <t>
-                    An endpoint (i.e., both the offerer and the answerer) MUST create an
-                    SDP media description ("m=" line) for each UDPTL-over-DTLS media
-                    stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
-                    "proto" field of the "m=" line.
-                </t>
-                <t>
-                    The offerer and answerer MUST follow the SDP offer/answer procedures
-                    defined in [RFCXXXX] in order to negotiate the DTLS association
-                    associated with the UDPTL-over-DTLS media stream. In addition,
-                    the offerer and answerer MUST use the SDP attributes defined for
-                    UDPTL over UDP, as defined in [ITU.T38.2010].
-                </t>
-            </section>
-            <section title="Update to Section 5.2.1. ICE Usage">
-                <t>
-                    This section is updated to use ICE related rules provided
-                    in this specification.
-                </t>
-                <t>
-                   The Interactive Connectivity Establishment (ICE) [RFC5245]
-                   considerations for DTLS-protected media are described in
-                   [RFCXXXX].
-                </t>
-            </section>
-        </section>
-    </section>
+            <figure>
+                <artwork align="left" alt="" height="" name="" type="" width="" xml:space="preserve"><![CDATA[
 
+Update to section 4:
+--------------------
+                
+OLD TEXT:
+
+4.  SDP Offerer/Answerer Procedures
+
+4.1.  General
+
+   An endpoint (i.e., both the offerer and the answerer) MUST create an
+   SDP media description ("m=" line) for each UDPTL-over-DTLS media
+   stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
+   "proto" field of the "m=" line.
+
+   The procedures in this section apply to an "m=" line associated with
+   a UDPTL-over-DTLS media stream.
+
+   In order to negotiate a UDPTL-over-DTLS media stream, the following
+   SDP attributes are used:
+
+   o  The SDP attributes defined for UDPTL over UDP, as described in
+      [ITU.T38.2010]; and
+
+   o  The SDP attributes, defined in [RFC4145] and [RFC4572], as
+      described in this section.
+
+   The endpoint MUST NOT use the SDP "connection" attribute [RFC4145].
+
+   In order to negotiate the TLS roles for the UDPTL-over-DTLS transport
+   connection, the endpoint MUST use the SDP "setup" attribute
+   [RFC4145].
+
+   If the endpoint supports, and is willing to use, a cipher suite with
+   an associated certificate, the endpoint MUST include an SDP
+   "fingerprint" attribute [RFC4572].  The endpoint MUST support SHA-256
+   for generating and verifying the SDP "fingerprint" attribute value.
+   The use of SHA-256 is preferred.  UDPTL over DTLS, at a minimum, MUST
+   support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 and MUST support
+   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.  UDPTL over DTLS MUST prefer
+   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and any other Perfect Forward
+   Secrecy (PFS) cipher suites over non-PFS cipher suites.
+   Implementations SHOULD disable TLS-level compression.
+
+   If a cipher suite with an associated certificate is selected during
+   the DTLS handshake, the certificate received during the DTLS
+   handshake MUST match the fingerprint received in the SDP
+   "fingerprint" attribute.  If the fingerprint does not match the
+   hashed certificate, then the endpoint MUST tear down the media
+   session immediately.  Note that it is permissible to wait until the
+   other side's fingerprint has been received before establishing the
+   connection; however, this may have undesirable latency effects.
+
+4.2.  Generating the Initial Offer
+
+   The offerer SHOULD assign the SDP "setup" attribute with a value of
+   "actpass", unless the offerer insists on being either the sender or
+   receiver of the DTLS ClientHello message, in which case the offerer
+   can use either a value of "active" (the offerer will be the sender of
+   ClientHello) or "passive" (the offerer will be the receiver of
+   ClientHello).  The offerer MUST NOT assign an SDP "setup" attribute
+   with a "holdconn" value.
+
+   If the offerer assigns the SDP "setup" attribute with a value of
+   "actpass" or "passive", the offerer MUST be prepared to receive a
+   DTLS ClientHello message before it receives the SDP answer.
+
+4.3.  Generating the Answer
+
+   If the answerer accepts the offered UDPTL-over-DTLS transport
+   connection, in the associated SDP answer, the answerer MUST assign an
+   SDP "setup" attribute with a value of either "active" or "passive",
+   according to the procedures in [RFC4145].  The answerer MUST NOT
+   assign an SDP "setup" attribute with a value of "holdconn".
+
+   If the answerer assigns an SDP "setup" attribute with a value of
+   "active" value, the answerer MUST initiate a DTLS handshake by
+   sending a DTLS ClientHello message on the negotiated media stream,
+   towards the IP address and port of the offerer.
+
+4.4.  Offerer Processing of the Answer
+
+   When the offerer receives an SDP answer, if the offerer ends up being
+   active it MUST initiate a DTLS handshake by sending a DTLS
+   ClientHello message on the negotiated media stream, towards the IP
+   address and port of the answerer.
+
+4.5.  Modifying the Session
+
+   Once an offer/answer exchange has been completed, either endpoint MAY
+   send a new offer in order to modify the session.  The endpoints can
+   reuse the existing DTLS association if the key fingerprint values and
+   transport parameters indicated by each endpoint are unchanged.
+   Otherwise, following the rules for the initial offer/answer exchange,
+   the endpoints can negotiate and create a new DTLS association and,
+   once created, delete the previous DTLS association, following the
+   same rules for the initial offer/answer exchange.  Each endpoint
+   needs to be prepared to receive data on both the new and old DTLS
+   associations as long as both are alive.
+   
+NEW TEXT:
+
+4.  SDP Offerer/Answerer Procedures
+
+   An endpoint (i.e., both the offerer and the answerer) MUST create an
+   SDP media description ("m=" line) for each UDPTL-over-DTLS media
+   stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
+   "proto" field of the "m=" line.
+
+   The offerer and answerer MUST follow the SDP offer/answer procedures
+   defined in [RFCXXXX] in order to negotiate the DTLS association
+   associated with the UDPTL-over-DTLS media stream. In addition,
+   the offerer and answerer MUST use the SDP attributes defined for
+   UDPTL over UDP, as defined in [ITU.T38.2010].
+
+
+Update to section 5.2.1:
+------------------------
+
+OLD TEXT:
+   
+5.2.1.  ICE Usage
+
+   When Interactive Connectivity Establishment (ICE) [RFC5245] is being
+   used, the ICE connectivity checks are performed before the DTLS
+   handshake begins.  Note that if aggressive nomination mode is used,
+   multiple candidate pairs may be marked valid before ICE finally
+   converges on a single candidate pair.  User Agents (UAs) MUST treat
+   all ICE candidate pairs associated with a single component as part of
+   the same DTLS association.  Thus, there will be only one DTLS
+   handshake even if there are multiple valid candidate pairs.  Note
+   that this may mean adjusting the endpoint IP addresses if the
+   selected candidate pair shifts, just as if the DTLS packets were an
+   ordinary media stream.  In the case of an ICE restart, the DTLS
+   handshake procedure is repeated, and a new DTLS association is
+   created.  Once the DTLS handshake is completed and the new DTLS
+   association has been created, the previous DTLS association is
+   deleted.
+
+   
+NEW TEXT:
+   
+5.2.1.  ICE Usage
+
+   The Interactive Connectivity Establishment (ICE) [RFC5245]
+   considerations for DTLS-protected media are described in
+   [RFCXXXX].
+
+                ]]></artwork>
+            </figure>
+        </section>
+	</section>
+    
     <section title="Security Considerations">
         <t>
             This specification does not modify the security considerations associated with DTLS, or

--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -5,10 +5,10 @@
 <?rfc compact="yes" ?>
 <?rfc sortrefs="no" ?>
 <rfc ipr="trust200902" category="std" docName="draft-ietf-mmusic-dtls-sdp-10.txt" updates="5763,7345" submissionType="IETF" xml:lang="en">
-<front>
+  <front>
     <title>
-        Using the SDP Offer/Answer Mechanism for DTLS
-    </title>
+		Using the SDP Offer/Answer Mechanism for DTLS
+	</title>
     <author fullname="Christer Holmberg" initials="C.H." surname="Holmberg">
         <organization abbrev="Ericsson">Ericsson</organization>
         <address>
@@ -22,7 +22,7 @@
             <phone></phone>
             <email>christer.holmberg@ericsson.com</email>
         </address>
-    </author>
+    </author>     	
     <author fullname="Roman Shpount" initials="R.S." surname="Shpount">
         <organization abbrev="TurboBridge">TurboBridge</organization>
         <address>
@@ -41,7 +41,7 @@
     <date year="2016" />
     <area>RAI</area>
     <abstract>
-        <t>
+		<t>
             This draft defines the SDP offer/answer procedures for negotiating and establishing
             a DTLS association. The draft also defines the criteria for when a new DTLS association
             must be established.
@@ -52,23 +52,23 @@
     </abstract>
 </front>
 <middle>
-    <section title="Introduction">
+    <section title="Introduction">        
             <t>
-                <xref format="default" pageno="false" target="RFC5763"/> defines SDP Offer/Answer
+                <xref format="default" pageno="false" target="RFC5763"/> defines SDP Offer/Answer 
                 procedures for SRTP-DTLS. <xref format="default" pageno="false" target="RFC7345"/>
                 defines SDP Offer/Answer procedures for UDPTL-DTLS. This specification
-                defines general Offer/Answer procedures for DTLS, based on the procedures in
+                defines general Offer/Answer procedures for DTLS, based on the procedures in 
                 <xref format="default" pageno="false" target="RFC5763"/>. Other specifications,
                 defining specific DTLS usages, can then reference this specification, in order
-                to ensure that the DTLS aspects are common among all usages. Having common
+                to ensure that the DTLS aspects are common among all usages. Having common 
                 procedures is essential when multiple usages share the same
-                DTLS association <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>.
+                DTLS association <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>. 
             </t>
             <t>
-                As defined in <xref format="default" pageno="false" target="RFC5763"/>, a new DTLS association
-                MUST be established when transport parameters are changed. Transport parameter change is not
-                well defined when Interactive Connectivity Establishment (ICE) <xref format="default"
-                pageno="false" target="RFC5245"/> is used. One possible way to determine a transport change is
+                As defined in <xref format="default" pageno="false" target="RFC5763"/>, a new DTLS association 
+                MUST be established when transport parameters are changed. Transport parameter change is not 
+                well defined when Interactive Connectivity Establishment (ICE) <xref format="default" 
+                pageno="false" target="RFC5245"/> is used. One possible way to determine a transport change is 
                 based on ufrag change, but the ufrag value is changed both when ICE is negotiated
                 and when ICE restart <xref format="default" pageno="false" target="RFC5245"/> occurs. These events
                 do not always require a new DTLS association to be established, but currently there is no way
@@ -78,13 +78,13 @@
                 is to be established/re-established. The attribute can be used both with and without ICE.
             </t>
     </section>
-
+		
     <section title="Conventions">
-        <t>
-            The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-            "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-            document are to be interpreted as described in <xref target="RFC2119"></xref>.
-        </t>
+		<t>
+			The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+			"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+			document are to be interpreted as described in <xref target="RFC2119"></xref>.
+		</t>
     </section>
 
     <section title="Establishing a new DTLS Association">
@@ -92,18 +92,18 @@
             <t>
                 A new DTLS association MUST be established in the following cases:
                 <list style="symbols">
-                    <t>
-                        The DTLS roles change;
-                    </t>
-                    <t>
-                        Any of the fingerprint values changes; or
-                    </t>
-                    <t>
-                        Any of the fingerprints are added or removed; or
-                    </t>
-                    <t>
-                        Value of 'dtls-association-id' attribute changes;
-                    </t>
+					<t>
+						The DTLS roles change;
+					</t>
+					<t>
+						Any of the fingerprint values changes; or
+					</t>
+					<t>
+						Any of the fingerprints are added or removed; or
+					</t>
+					<t>
+						Value of 'dtls-association-id' attribute changes;
+					</t>                    
                 </list>
             </t>
             <t>
@@ -114,13 +114,13 @@
                 when transport parameters change.
             </t>
             <t>
-                Whenever an entity determines, based on the criteria above, that a new DTLS association
-                is required, the entity MUST initiate an associated SDP offer/answer transaction, following the
+                Whenever an entity determines, based on the criteria above, that a new DTLS association 
+                is required, the entity MUST initiate an associated SDP offer/answer transaction, following the 
                 procedures in <xref target="sec-oa"/>.
             </t>
             <t>
                 The sections below describe typical cases where a new DTLS association needs to be established.
-            </t>
+            </t>            
         </section>
         <section title="Change of Local Transport Parameters" anchor="sec-dtls-transport">
             <t>
@@ -150,7 +150,7 @@
             are unchanged.
         </t>
         <figure>
-            <artwork align="left"><![CDATA[
+		    <artwork align="left"><![CDATA[
 
        Name: dtls-association-id
 
@@ -167,9 +167,9 @@
        Example:
 
            a=dtls-association-id:abc3dl
-
-            ]]></artwork>
-        </figure>
+           
+           	]]></artwork>
+		</figure>
         <t>
             A change in 'dtls-association-id' attribute value indicates that a new
             DTLS association MUST be established. A 'dtls-association-id' attribute
@@ -185,11 +185,11 @@
             defined in this specification or an implementation which allocates a new
             temporary certificate for each association and uses change in fingerprint
             to indicate new association), other means needs to be used in order for
-            endpoints to determine whether an offer or answer is associated with an
+            endpoints to determine whether an offer or answer is associated with an 
             event that requires the DTLS association to be re-established.
         </t>
         <t>
-            The mux category <xref target="I-D.ietf-mmusic-sdp-mux-attributes"/>
+            The mux category <xref target="I-D.ietf-mmusic-sdp-mux-attributes"/> 
             for the 'dtls-association-id' attribute is 'IDENTICAL', which means that
             the attribute value must be identical across all media descriptions
             being multiplexed <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>.
@@ -197,41 +197,41 @@
         <t>
             For RTP-based media, the 'dtls-association-id' attribute apply to whole associated
             media description. The attribute MUST NOT be defined per source (using the
-            SDP 'ssrc' attribute <xref format="default" pageno="false" target="RFC5576"/>).
+            SDP 'ssrc' attribute <xref format="default" pageno="false" target="RFC5576"/>). 
         </t>
         <t>
-            The SDP Offer/Answer <xref format="default" pageno="false" target="RFC3264"/>
+            The SDP Offer/Answer <xref format="default" pageno="false" target="RFC3264"/> 
             procedures associated with the attribute are defined in <xref target="sec-oa"/>
         </t>
     </section>
-
+    
     <section title="SDP Offer/Answer Procedures" anchor="sec-oa">
         <section title="General">
             <t>
                 This section defines the generic SDP offer/answer procedures for negotiating
-                a DTLS association. Additional procedures (e.g. regarding usage of specific SDP
-                attributes etc) for individual DTLS usages (e.g. SRTP-DTLS) are outside the scope
+                a DTLS association. Additional procedures (e.g. regarding usage of specific SDP 
+                attributes etc) for individual DTLS usages (e.g. SRTP-DTLS) are outside the scope 
                 of this specification, and need to be specified in a usage specific specification.
             </t>
             <t>
-                NOTE: The procedures in this section are generalizations of procedures first
-                specified in SRTP-DTLS <xref format="default" pageno="false" target="RFC5763"/>,
+                NOTE: The procedures in this section are generalizations of procedures first 
+                specified in SRTP-DTLS <xref format="default" pageno="false" target="RFC5763"/>, 
                 with the addition of usage of the SDP 'dtls-association-id' attribute. That document is
                 herein revised to make use of these new procedures.
             </t>
-            <t>
-                The procedures in this section apply to an SDP media description ("m=" line) associated
-                a DTLS-protected media/data stream.
-            </t>
-            <t>
+			<t>
+                The procedures in this section apply to an SDP media description ("m=" line) associated 
+                a DTLS-protected media/data stream.				
+			</t>
+			<t>
                 In order to negotiate a DTLS association, the following SDP attributes are used:
                 <list style="symbols">
                     <t>
-                        The SDP 'setup' attribute, defined in <xref target="RFC4145" pageno="false"
+                        The SDP 'setup' attribute, defined in <xref target="RFC4145" pageno="false" 
                         format="default" />, is used to negotiate the DTLS setup roles;
                     </t>
                     <t>
-                        The SDP 'fingerprint' attribute, defined in <xref target="RFC4572"
+                        The SDP 'fingerprint' attribute, defined in <xref target="RFC4572" 
                         pageno="false" format="default" />, is used to provide fingerprint
                         values for the association; and
                     </t>
@@ -242,21 +242,21 @@
                         did not change.
                     </t>
                 </list>
+			</t>
+			<t>
+				This specification does not define the usage of the SDP 'connection' attribute 
+				<xref target="RFC4145" pageno="false" format="default" /> for negotiating a DTLS 
+				connection. However, the attribute MAY be used if the DTLS association is used
+				together with another protocol, e.g. SCTP or TCP, for which the usage of the
+				attribute has been defined.				
             </t>
             <t>
-                This specification does not define the usage of the SDP 'connection' attribute
-                <xref target="RFC4145" pageno="false" format="default" /> for negotiating a DTLS
-                connection. However, the attribute MAY be used if the DTLS association is used
-                together with another protocol, e.g. SCTP or TCP, for which the usage of the
-                attribute has been defined.
-            </t>
-            <t>
-                Unlike for TCP and TLS connections, endpoints MUST NOT use the
+                Unlike for TCP and TLS connections, endpoints MUST NOT use the 
                 SDP 'setup' attribute 'holdconn' value when negotiating a DTLS association.
             </t>
             <t>
                 Endpoints MUST support SHA-256 for generating and verifying any fingerprint
-                value associated with the DTLS association. The use of SHA-256 is preferred.
+                value associated with the DTLS association. The use of SHA-256 is preferred. 
             </t>
             <t>
                 Endpoints MUST, at a minimum, support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 
@@ -272,12 +272,12 @@
 				session immediately. Note that it is permissible to wait until the other side's 
 				fingerprint has been received before establishing the connection; however, this 
 				may have undesirable latency effects.
-            </t>
+			</t>            
         </section>
-
+        
         <section title="Generating the Initial SDP Offer"  anchor="sec-oa-offer">
             <t>
-                When the offerer sends the initial offer, and the offerer wants to establish a
+                When the offerer sends the initial offer, and the offerer wants to establish a 
                 DTLS association, it MUST guarantee that combination of fingerprint values and 
                 the SDP 'dtls-association-id' attribute value is unique across all the DTLS associations.
                 If the end point generates a new temporary self signed certificate for each new DTLS association,
@@ -300,7 +300,7 @@
                 is established by the answerer) from the answerer before it receives the SDP answer.
             </t>
         </section>
-        <section title="Generating the Answer">
+        <section title="Generating the Answer">       
             <t>
                 If an answerer receives an offer and no previous DTLS association existed, or an offer in which
                 any of the fingerprint values changed, or any fingerprints where added or removed, or which caused
@@ -322,7 +322,7 @@
                 for the SDP 'dtls-association-id' attribute, in order to avoid collisions, it is recommended to use at
                 least 128 bits of randomness, which means an alphanumeric string at least 25 characters long.
             </t>
-            <t>
+            <t>            
                 In addition, the answerer MUST insert an SDP 'setup' attribute according
                 to the procedures in <xref format="default" pageno="false" target="RFC4145"/>, and
                 one or more SDP 'fingerprint' attributes according to the procedures in <xref format="default"
@@ -371,28 +371,28 @@
         </section>
         <section title="Modifying the Session">
             <t>
-                When the offerer sends a subsequent offer, and if the offerer wants to establish a new
+                When the offerer sends a subsequent offer, and if the offerer wants to establish a new 
                 DTLS association, the offerer MUST guarantee that combination of fingerprint values and 
                 the SDP 'dtls-association-id' attribute value is unique across all the DTLS associations.
                 In addition, the offerer MUST insert an SDP 'setup' attribute  according to the procedures
                 in <xref format="default" pageno="false" target="RFC4145"/>, and one or more SDP
                 'fingerprint' attributes according to the procedures in <xref format="default" pageno="false"
                 target="RFC4572"/>, in the offer.
-            </t>
+             </t>
              <t>
-                When the offerer sends a subsequent offer, and the offerer does not want to establish
-                a new DTLS association, and if a previously established DTLS association exists, the
+                when the offerer sends a subsequent offer, and the offerer does not want to establish
+                a new DTLS association, and if a previously established DTLS association exists, the 
                 offerer MUST insert the SDP 'dtls-association-id' attribute and fingerprint values
                 set to the same values as previously sent values for these attributes, an SDP 'setup' attribute with a value that does 
                 not change the previously negotiated DTLS roles, in the offer.
             </t>
             <t>
-                NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive
+                NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive 
                 data on both the new and old DTLS associations as long as both are alive.
             </t>
         </section>
-    </section>
-
+	</section>
+    
     <section title="ICE Considerations" anchor="sec-dtls-reest-ice">
         <t>
             When ICE is used, the ICE connectivity checks are performed before the DTLS
@@ -401,18 +401,18 @@
             converges on a single candidate pair.
         </t>
         <t>
-            An ICE restart <xref format="default" pageno="false" target="RFC5245"/>
-            does not by default require a new DTLS association to be established.
+            An ICE restart <xref format="default" pageno="false" target="RFC5245"/> 
+            does not by default require a new DTLS association to be established.             
         </t>
         <t>
-            As defined in <xref format="default" pageno="false" target="RFC5763"/>,
-            each ICE candidate associated with a component is treated as being part of the
-            same DTLS association. Therefore, from a DTLS perspective it is not considered
-            a change of local transport parameters when an endpoint switches between those
+            As defined in <xref format="default" pageno="false" target="RFC5763"/>, 
+            each ICE candidate associated with a component is treated as being part of the 
+            same DTLS association. Therefore, from a DTLS perspective it is not considered 
+            a change of local transport parameters when an endpoint switches between those 
             ICE candidates.
         </t>
     </section>
-
+    
     <section title="Transport Protocol Considerations" anchor="sec-dtls-cons-trans">
         <section title="Transport Re-Usage" anchor="sec-dtls-cons-trans-reuse">
             <t>
@@ -423,20 +423,20 @@
             </t>
         </section>
     </section>
-
+    
     <section title="SIP Considerations">
         <t>
-            When the Session Initiation Protocol (SIP) <xref format="default" pageno="false"
-            target="RFC3261"/> is used as the signal protocol for establishing a multimedia
-            session, dialogs <xref format="default" pageno="false" target="RFC3261"/> might be
-            established between the caller and multiple callees. This is referred to as forking.
-            If forking occurs, separate DTLS associations MUST be established between the caller
+            When the Session Initiation Protocol (SIP) <xref format="default" pageno="false" 
+            target="RFC3261"/> is used as the signal protocol for establishing a multimedia 
+            session, dialogs <xref format="default" pageno="false" target="RFC3261"/> might be 
+            established between the caller and multiple callees. This is referred to as forking. 
+            If forking occurs, separate DTLS associations MUST be established between the caller 
             and each callee.
         </t>
-        <t>
-            It is possible to send an INVITE request which does not contain an SDP offer. Such
+		<t>
+            It is possible to send an INVITE request which does not contain an SDP offer. Such 
             INVITE request is often referred to as an 'empty INVITE', or an 'offer-less INVITE'.
-            The receiving endpoint will include the SDP offer in a response associated with the
+            The receiving endpoint will include the SDP offer in a response associated with the 
             response. When the endpoint generates such SDP offer, if a previously established
             DTLS association exists, the offerer SHOULD insert the SDP 'dtls-association-id' 
             attribute and fingerprint values set to the same values as previously sent values
@@ -447,9 +447,9 @@
             target="RFC4145"/> and if ICE is used, ICE restart MUST be initiated as defined in
             <xref format="default" pageno="false" target="RFC5763"/>.
         </t>
-    </section>
+	</section>
 
-
+    
     <section title="RFC Updates">
         <section title="General">
             <t>
@@ -467,46 +467,47 @@ Update to section 5:
 OLD TEXT:
 
 5.  Establishing a Secure Channel
-                   The two endpoints in the exchange present their identities as part of
-                   the DTLS handshake procedure using certificates.  This document uses
-                   certificates in the same style as described in "Connection-Oriented
-                   Media Transport over the Transport Layer Security (TLS) Protocol in
-                   the Session Description Protocol (SDP)" [RFC4572].
 
-                   If self-signed certificates are used, the content of the
-                   subjectAltName attribute inside the certificate MAY use the uniform
-                   resource identifier (URI) of the user.  This is useful for debugging
-                   purposes only and is not required to bind the certificate to one of
-                   the communication endpoints.  The integrity of the certificate is
+   The two endpoints in the exchange present their identities as part of
+   the DTLS handshake procedure using certificates.  This document uses
+   certificates in the same style as described in "Connection-Oriented
+   Media Transport over the Transport Layer Security (TLS) Protocol in
+   the Session Description Protocol (SDP)" [RFC4572].
+
+   If self-signed certificates are used, the content of the
+   subjectAltName attribute inside the certificate MAY use the uniform
+   resource identifier (URI) of the user.  This is useful for debugging
+   purposes only and is not required to bind the certificate to one of
+   the communication endpoints.  The integrity of the certificate is
    ensured through the fingerprint attribute in the SDP.  The
    subjectAltName is not an important component of the certificate
    verification.
 
-                   The generation of public/private key pairs is relatively expensive.
-                   Endpoints are not required to generate certificates for each session.
+   The generation of public/private key pairs is relatively expensive.
+   Endpoints are not required to generate certificates for each session.
 
-                   The offer/answer model, defined in [RFC3264], is used by protocols
-                   like the Session Initiation Protocol (SIP) [RFC3261] to set up
+   The offer/answer model, defined in [RFC3264], is used by protocols
+   like the Session Initiation Protocol (SIP) [RFC3261] to set up
    multimedia sessions.  In addition to the usual contents of an SDP
    [RFC4566] message, each media description ("m=" line and associated
    parameters) will also contain several attributes as specified in
    [RFC5764], [RFC4145], and [RFC4572].
 
-                   When an endpoint wishes to set up a secure media session with another
-                   endpoint, it sends an offer in a SIP message to the other endpoint.
+   When an endpoint wishes to set up a secure media session with another
+   endpoint, it sends an offer in a SIP message to the other endpoint.
    This offer includes, as part of the SDP payload, the fingerprint of
    the certificate that the endpoint wants to use.  The endpoint SHOULD
-                   send the SIP message containing the offer to the offerer's SIP proxy
-                   over an integrity protected channel.  The proxy SHOULD add an
-                   Identity header field according to the procedures outlined in
-                   [RFC4474].  The SIP message containing the offer SHOULD be sent to
-                   the offerer's SIP proxy over an integrity protected channel.  When
-                   the far endpoint receives the SIP message, it can verify the identity
-                   of the sender using the Identity header field.  Since the Identity
-                   header field is a digital signature across several SIP header fields,
-                   in addition to the body of the SIP message, the receiver can also be
-                   certain that the message has not been tampered with after the digital
-                   signature was applied and added to the SIP message.
+   send the SIP message containing the offer to the offerer's SIP proxy
+   over an integrity protected channel.  The proxy SHOULD add an
+   Identity header field according to the procedures outlined in
+   [RFC4474].  The SIP message containing the offer SHOULD be sent to
+   the offerer's SIP proxy over an integrity protected channel.  When
+   the far endpoint receives the SIP message, it can verify the identity
+   of the sender using the Identity header field.  Since the Identity
+   header field is a digital signature across several SIP header fields,
+   in addition to the body of the SIP message, the receiver can also be
+   certain that the message has not been tampered with after the digital
+   signature was applied and added to the SIP message.
 
    The far endpoint (answerer) may now establish a DTLS association with
    the offerer.  Alternately, it can indicate in its answer that the
@@ -527,11 +528,14 @@ OLD TEXT:
    this point, the offerer can accept or reject the peer's certificate
    and the offerer can indicate to the end user that the media is
    secured.
+
    Note that the entire authentication and key exchange for securing the
    media traffic is handled in the media path through DTLS.  The
    signaling path is only used to verify the peers' certificate
    fingerprints.
+
    The offer and answer MUST conform to the following requirements.
+
    o  The endpoint MUST use the setup attribute defined in [RFC4145].
       The endpoint that is the offerer MUST use the setup attribute
       value of setup:actpass and be prepared to receive a client_hello
@@ -543,25 +547,34 @@ OLD TEXT:
       occur in parallel.  Thus, setup:active is RECOMMENDED.  Whichever
       party is active MUST initiate a DTLS handshake by sending a
       ClientHello over each flow (host/port quartet).
+
    o  The endpoint MUST NOT use the connection attribute defined in
       [RFC4145].
+
    o  The endpoint MUST use the certificate fingerprint attribute as
       specified in [RFC4572].
+
    o  The certificate presented during the DTLS handshake MUST match the
       fingerprint exchanged via the signaling path in the SDP.  The
       security properties of this mechanism are described in Section 8.
+
    o  If the fingerprint does not match the hashed certificate, then the
       endpoint MUST tear down the media session immediately.  Note that
       it is permissible to wait until the other side's fingerprint has
       been received before establishing the connection; however, this
       may have undesirable latency effects.
+
+   
 NEW TEXT:
+
 5.  Establishing a Secure Channel
+
    The two endpoints in the exchange present their identities as part of
    the DTLS handshake procedure using certificates.  This document uses
    certificates in the same style as described in "Connection-Oriented
    Media Transport over the Transport Layer Security (TLS) Protocol in
    the Session Description Protocol (SDP)" [RFC4572].
+
    If self-signed certificates are used, the content of the
    subjectAltName attribute inside the certificate MAY use the uniform
    resource identifier (URI) of the user.  This is useful for debugging
@@ -847,24 +860,24 @@ NEW TEXT:
         </section>
 	</section>
     
-    <section title="Security Considerations">
-        <t>
-            This specification does not modify the security considerations associated with DTLS, or
+	<section title="Security Considerations">
+		<t>
+			This specification does not modify the security considerations associated with DTLS, or
             the SDP offer/answer mechanism. In addition to the introduction of the SDP
             'dtls-connection' attribute, the specification simply clarifies the procedures for
             negotiating and establishing a DTLS association.
-        </t>
-    </section>
-
-    <section anchor="section.iana" title="IANA Considerations">
+		</t>
+	</section>
+	
+	<section anchor="section.iana" title="IANA Considerations">
         <t>
-            This document updates the "Session Description Protocol Parameters" registry
+            This document updates the "Session Description Protocol Parameters" registry 
             as specified in Section 8.2.2 of <xref target="RFC4566" pageno="false" format="default"/>.
             Specifically, it adds the SDP dtls-association-id attribute to the table for SDP
             media level attributes.
         </t>
         <figure>
-            <artwork align="left"><![CDATA[
+			<artwork align="left"><![CDATA[
 
     Attribute name: dtls-association-id
     Type of attribute: media-level
@@ -873,21 +886,21 @@ NEW TEXT:
     Appropriate Values: see Section 4
     Contact name: Christer Holmberg
     Category: IDENTICAL
-
-            ]]></artwork>
-        </figure>
-    </section>
-
+    
+			]]></artwork>
+		</figure>        
+	</section>
+                   
     <section title="Acknowledgments">
-        <t>
+		<t>
             Thanks to Justin Uberti, Martin Thomson, Paul Kyzivat, Jens Guballa,
-            Charles Eckel and Gonzalo Salgueiro for providing comments and
+            Charles Eckel and Gonzalo Salgueiro for providing comments and 
             suggestions on the draft.
         </t>
-    </section>
-
-    <section title="Change Log">
-        <t>[RFC EDITOR NOTE: Please remove this section when publishing]</t>
+	</section>
+		
+	<section title="Change Log">	
+		<t>[RFC EDITOR NOTE: Please remove this section when publishing]</t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-11
             <list style="symbols">
                 <t>Modified document to use dtls-association-id instead of dtls-connection</t>
@@ -895,40 +908,40 @@ NEW TEXT:
             </list>
         </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-08
-            <list style="symbols">
+			<list style="symbols">
                 <t>Offer/Answer section modified in order to allow sending of multiple SDP 'fingerprint' attributes.</t>
                 <t>Terminology made consistent: 'DTLS connection' replaced with 'DTLS association'.</t>
                 <t>Editorial changes based on comments from Paul Kyzivat.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-07
-            <list style="symbols">
+			<list style="symbols">
                 <t>Reference to RFC 7315 replaced with reference to RFC 7345.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-06
-            <list style="symbols">
+			<list style="symbols">
                 <t>Text on restrictions regarding spanning a DTLS association over multiple transports added.</t>
                 <t>Mux category added to IANA Considerations.</t>
                 <t>Normative text regarding mux category and source-specific applicability added.</t>
                 <t>Reference to RFC 7315 added.</t>
                 <t>Clarified that offerer/answerer that has not been updated to support this specification will
                 not include the dtls-connection attribute in offers and answers.</t>
-                <t>Editorial corrections based on WGLC comments from Charles Eckel.</t>
-            </list>
-        </t>
+				<t>Editorial corrections based on WGLC comments from Charles Eckel.</t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-05
-            <list style="symbols">
+			<list style="symbols">
                 <t>Text on handling offer/answer error conditions added.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-04
-            <list style="symbols">
+			<list style="symbols">
                 <t>Editorial nits fixed based on comments from Paul Kyzivat:</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-03
-            <list style="symbols">
+			<list style="symbols">
                 <t>Changes based on comments from Paul Kyzivat:</t>
                 <t>- Modification of dtls-connection attribute section.</t>
                 <t>- Removal of IANA considerations subsection.</t>
@@ -936,51 +949,51 @@ NEW TEXT:
                 <t>Changes based on comments from Martin Thompson:</t>
                 <t>- Abbreviations section removed.</t>
                 <t>- Clarify that a new DTLS association requires a new o/a transaction.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-02
-            <list style="symbols">
+			<list style="symbols">
                 <t>- Updated RFCs added to boilerplate.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-01
-            <list style="symbols">
+			<list style="symbols">
                 <t>- Annex regarding 'dtls-connection-id' attribute removed.</t>
                 <t>- Additional SDP offer/answer procedures, related to certificates, added.</t>
                 <t>- Updates to RFC 5763 and RFC 7345 added.</t>
                 <t>- Transport protocol considerations added.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-ietf-mmusic-sdp-dtls-00
-            <list style="symbols">
+			<list style="symbols">
                 <t>- SDP 'connection' attribute replaced with new 'dtls-connection' attribute.</t>
                 <t>- IANA Considerations added.</t>
                 <t>- E-mail regarding 'dtls-connection-id' attribute added as Annex.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-holmberg-mmusic-sdp-dtls-01
-            <list style="symbols">
+			<list style="symbols">
                 <t>- draft-ietf-mmusic version of draft submitted.</t>
                 <t>- Draft file name change (sdp-dtls -> dtls-sdp) due to collision with another expired draft.</t>
                 <t>- Clarify that if ufrag in offer is unchanged, it must be unchanged in associated answer.</t>
                 <t>- SIP Considerations section added.</t>
                 <t>- Section about multiple SDP fingerprint attributes added.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
         <t>Changes from draft-holmberg-mmusic-sdp-dtls-00
-            <list style="symbols">
+			<list style="symbols">
                 <t>- Editorial changes and clarifications.</t>
-            </list>
-        </t>
+			</list>
+		</t>		
 
-    </section>
+	</section>
 </middle>
 
 <back>
     <references title="Normative References">
-        <?rfc include="reference.RFC.2119"?>
+		<?rfc include="reference.RFC.2119"?>
         <?rfc include="reference.RFC.3261"?>
-        <?rfc include="reference.RFC.3264"?>
+		<?rfc include="reference.RFC.3264"?>
         <?rfc include="reference.RFC.4145"?>
         <?rfc include="reference.RFC.4566"?>
         <?rfc include="reference.RFC.4572"?>
@@ -988,12 +1001,13 @@ NEW TEXT:
         <?rfc include="reference.RFC.5245"?>
         <?rfc include="reference.RFC.5763"?>
         <?rfc include="reference.RFC.7345"?>
-    </references>
+    </references>    
     <references title="Informative References">
         <?rfc include="reference.RFC.5576"?>
-        <?rfc include="reference.RFC.6083"?>
+		<?rfc include="reference.RFC.6083"?>
         <?rfc include="reference.I-D.draft-ietf-mmusic-sdp-mux-attributes-12"?>
         <?rfc include="reference.I-D.draft-ietf-mmusic-sdp-bundle-negotiation-25"?>
-    </references>
+    </references>    
+
 </back>
 </rfc>

--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -299,13 +299,13 @@
         </section>
         <section title="Generating the Answer">
             <t>
-                If an answerer receives an offer that establishes a new SDP session, or an offer in which
-                any of the fingerprint values changed, or any fingerprints where added or removed, or DTLS 
-                setup role changed, or SDP 'dtls-association-id' attribute was added or new value of 
-                SDP 'dtls-association-id' attribute was specified, answerer MUST establish a new DTLS association.
-                If an offer with the same fingerprint values, setup role, and SDP 'dtls-association-id' attribute
-                was received in existing SDP session, answerer can reuse an existing DTLS association or it 
-                can choose to establish a new DTLS association.
+                If an answerer receives an offer and no previous DTLS association existed, or an offer in which
+                any of the fingerprint values changed, or any fingerprints where added or removed, or which caused
+                the negotiated DTLS setup role to change, or SDP 'dtls-association-id' attribute was added or new 
+                value of SDP 'dtls-association-id' attribute was specified, answerer MUST establish a new DTLS association.
+                If an offer was received with the same fingerprint and SDP 'dtls-association-id' attribute values,
+                and which did not change the negotiated DTLS setup role, the answerer can reuse this existing
+                DTLS association or it can choose to establish a new DTLS association.
             </t>
             <t>
                 If answerer needs to establish a new DTLS association, it MUST guarantee that combination of

--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -293,7 +293,7 @@
                 if ICE is used, which were not recently used for any other DTLS association.
             </t>
             <t>
-                The offerer offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
+                The offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
                 is established by the answerer) from the answerer before it receives the SDP answer.
             </t>
         </section>
@@ -389,7 +389,7 @@
                 a new DTLS association, and if a previously established DTLS association exists, the
                 offerer MUST insert the SDP 'dtls-association-id' attribute and fingerprint values
                 set to the same values as previously sent values for these attributes, and the SDP 'setup'
-                attribute set to the previously negotiated role for this DTLS association, in the answer.
+                attribute set to the previously negotiated role for this DTLS association, in the offer.
             </t>
             <t>
                 NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive

--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -5,10 +5,10 @@
 <?rfc compact="yes" ?>
 <?rfc sortrefs="no" ?>
 <rfc ipr="trust200902" category="std" docName="draft-ietf-mmusic-dtls-sdp-10.txt" updates="5763,7345" submissionType="IETF" xml:lang="en">
-  <front>
+<front>
     <title>
-		Using the SDP Offer/Answer Mechanism for DTLS
-	</title>
+        Using the SDP Offer/Answer Mechanism for DTLS
+    </title>
     <author fullname="Christer Holmberg" initials="C.H." surname="Holmberg">
         <organization abbrev="Ericsson">Ericsson</organization>
         <address>
@@ -22,7 +22,7 @@
             <phone></phone>
             <email>christer.holmberg@ericsson.com</email>
         </address>
-    </author>     	
+    </author>
     <author fullname="Roman Shpount" initials="R.S." surname="Shpount">
         <organization abbrev="TurboBridge">TurboBridge</organization>
         <address>
@@ -41,50 +41,50 @@
     <date year="2016" />
     <area>RAI</area>
     <abstract>
-		<t>
+        <t>
             This draft defines the SDP offer/answer procedures for negotiating and establishing
             a DTLS association. The draft also defines the criteria for when a new DTLS association
             must be established.
         </t>
         <t>
-            This draft defines a new SDP media-level attribute, 'dtls-connection'.
+            This draft defines a new SDP media-level attribute, 'dtls-association-id'.
         </t>
     </abstract>
 </front>
 <middle>
-    <section title="Introduction">        
+    <section title="Introduction">
             <t>
-                <xref format="default" pageno="false" target="RFC5763"/> defines SDP Offer/Answer 
+                <xref format="default" pageno="false" target="RFC5763"/> defines SDP Offer/Answer
                 procedures for SRTP-DTLS. <xref format="default" pageno="false" target="RFC7345"/>
                 defines SDP Offer/Answer procedures for UDPTL-DTLS. This specification
-                defines general Offer/Answer procedures for DTLS, based on the procedures in 
+                defines general Offer/Answer procedures for DTLS, based on the procedures in
                 <xref format="default" pageno="false" target="RFC5763"/>. Other specifications,
                 defining specific DTLS usages, can then reference this specification, in order
-                to ensure that the DTLS aspects are common among all usages. Having common 
+                to ensure that the DTLS aspects are common among all usages. Having common
                 procedures is essential when multiple usages share the same
-                DTLS association <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>. 
+                DTLS association <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>.
             </t>
             <t>
-                As defined in <xref format="default" pageno="false" target="RFC5763"/>, a new DTLS association 
-                MUST be established when transport parameters are changed. Transport parameter change is not 
-                well defined when Interactive Connectivity Establishment (ICE) <xref format="default" 
-                pageno="false" target="RFC5245"/> is used. One possible way to determine a transport change is 
+                As defined in <xref format="default" pageno="false" target="RFC5763"/>, a new DTLS association
+                MUST be established when transport parameters are changed. Transport parameter change is not
+                well defined when Interactive Connectivity Establishment (ICE) <xref format="default"
+                pageno="false" target="RFC5245"/> is used. One possible way to determine a transport change is
                 based on ufrag change, but the ufrag value is changed both when ICE is negotiated
                 and when ICE restart <xref format="default" pageno="false" target="RFC5245"/> occurs. These events
                 do not always require a new DTLS association to be established, but currently there is no way
                 to explicitly indicate in an SDP offer or answer whether a new DTLS association is required.
-                To solve that problem, this draft defines a new SDP attribute, 'dtls-connection'. The attribute 
-                is used in SDP offers and answers to explicitly indicate whether a new DTLS association 
+                To solve that problem, this draft defines a new SDP attribute, 'dtls-association-id'. The change in this
+                attribute value is used in SDP offers and answers to explicitly indicate whether a new DTLS association
                 is to be established/re-established. The attribute can be used both with and without ICE.
             </t>
     </section>
-		
+
     <section title="Conventions">
-		<t>
-			The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-			"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
-			document are to be interpreted as described in <xref target="RFC2119"></xref>.
-		</t>
+        <t>
+            The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+            "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+            document are to be interpreted as described in <xref target="RFC2119"></xref>.
+        </t>
     </section>
 
     <section title="Establishing a new DTLS Association">
@@ -92,62 +92,67 @@
             <t>
                 A new DTLS association MUST be established in the following cases:
                 <list style="symbols">
-					<t>
-						The DTLS roles change;
-					</t>
-					<t>
-						A fingerprint (certificate) value changes; or
-					</t>
-					<t>
-                        The intent to establish of a new DTLS association is
-                        explicitly signaled;
-					</t>                    
+                    <t>
+                        The DTLS roles change;
+                    </t>
+                    <t>
+                        Any of the fingerprint values changes; or
+                    </t>
+                    <t>
+                        Any of the fingerprints are added or removed; or
+                    </t>
+                    <t>
+                        Value of 'dtls-association-id' attribute changes;
+                    </t>
                 </list>
             </t>
             <t>
-                NOTE: The first two items list above are based on the procedures 
+                NOTE: The first three items list above are based on the procedures
                 in <xref format="default" pageno="false" target="RFC5763"/>.
-                This draft adds the support for explicit signaling.                
+                This draft adds ability to signal the need to establish new DTLS association by changing
+                'dtls-association-id' and removes underspecified requirement to establish new DTLS association
+                when transport parameters change.
             </t>
             <t>
-                Whenever an entity determines, based on the criteria above, that a new DTLS association 
-                is required, the entity MUST initiate an associated SDP offer/answer transaction, following the 
+                Whenever an entity determines, based on the criteria above, that a new DTLS association
+                is required, the entity MUST initiate an associated SDP offer/answer transaction, following the
                 procedures in <xref target="sec-oa"/>.
             </t>
             <t>
                 The sections below describe typical cases where a new DTLS association needs to be established.
-            </t>            
+            </t>
         </section>
         <section title="Change of Local Transport Parameters" anchor="sec-dtls-transport">
             <t>
-                If an endpoint modifies its local transport parameters (address and/or port), and if the modification
-                requires a new DTLS association, the endpoint MUST change its DTLS role, change its fingerprint value, and/or
-                use the SDP 'dtls-connection' attribute with a 'new' value <xref target="sec-dcon-attr"/>.
+                If an endpoint modifies its local transport parameters (address and/or port), and if the modification requires
+                a new DTLS association, the endpoint MUST either change its DTLS setup role, change of any of the set of the
+                fingerprint values, or include the SDP 'dtls-association-id' with a new unique value <xref target="sec-dassid-attr"/>.
             </t>
             <t>
-                If the underlying transport explicitly prohibits a DTLS association to span multiple transports,
-                the SDP 'dtls-connection' attribute MUST be set to 'new' if the transport is changed. An example of such
-                case is when DTLS is carried over SCTP, as described in <xref format="default" pageno="false" target="RFC6083"/>.
+                If the underlying transport explicitly prohibits a DTLS association to span multiple transports, and if
+                none of the fingerprints or DTLS setup role changed, the SDP 'dtls-association-id' attribute MUST be set to
+                a new unique value if the transport is changed. An example of such case is when DTLS is carried over SCTP,
+                as described in <xref format="default" pageno="false" target="RFC6083"/>.
             </t>
         </section>
         <section title="Change of ICE ufrag value" anchor="sec-dtls-ufrag">
             <t>
                 If an endpoint uses ICE, and modifies a local ufrag value, and if the modification
-                requires a new DTLS association, the endpoint MUST either change its DTLS role, a fingerprint value and/or
-                use the SDP 'dtls-connection' attribute with a 'new' value <xref target="sec-dcon-attr"/>.
+                requires a new DTLS association, the endpoint MUST either change its DTLS setup role, change of any of the set of the
+                fingerprint values, or include the SDP 'dtls-association-id' with a new unique value <xref target="sec-dassid-attr"/>.
             </t>
         </section>
     </section>
-	<section title="SDP dtls-connection Attribute" anchor="sec-dcon-attr">
+    <section title="SDP dtls-association-id Attribute" anchor="sec-dassid-attr">
         <t>
-            The SDP 'connection' attribute <xref format="default" pageno="false" target="RFC4145"/> 
-            was originally defined for connection-oriented protocols, e.g. TCP and TLS. This section 
-            defines a similar attribute, 'dtls-connection', to be used with DTLS.
+            This section defines 'dtls-association-id' attribute which is used with DTLS to signal that new DTLS association MUST 
+            be established when all other parameters association related attributes such fingerprint values and DTLS setup role 
+            are unchanged.
         </t>
         <figure>
-		    <artwork align="left"><![CDATA[
+            <artwork align="left"><![CDATA[
 
-       Name: dtls-connection
+       Name: dtls-association-id
 
        Value: conn-value
 
@@ -157,160 +162,187 @@
 
        Syntax:
 
-           conn-value = "new" / "existing"
+           conn-value = 1*256alphanum
 
        Example:
 
-           a=dtls-connection:existing
-           
-           	]]></artwork>
-		</figure>
+           a=dtls-association-id:abc3dl
+
+            ]]></artwork>
+        </figure>
         <t>
-            A 'dtls-connection' attribute value of 'new' indicates that a new
-            DTLS association MUST be established. A 'dtls-connection' attribute
-            value of 'existing' indicates an intention to reuse an existing
-            association.
+            A change in 'dtls-association-id' attribute value indicates that a new
+            DTLS association MUST be established. A 'dtls-association-id' attribute
+            with the same value as the value used to establish existing association
+            indicates an intention to reuse an existing association.
         </t>
         <t>
-            Unlike the SDP 'connection' attribute for TLS, there is no default
-            value defined for the 'dtls-connection' attribute.  Implementations
-            that wish to use the attribute MUST explicitly include it in SDP
-            offers and answers. If an offer or answer does not contain an
+            There is no default value defined for the 'dtls-association-id' attribute.
+            Implementations that wish to use the attribute MUST explicitly include it
+            in SDP offers and answers. If an offer or answer does not contain an
             attribute (this could happen if the offerer or answerer represents an
             existing implementation that has not been updated to support the attribute
-            defined in this specification), other means needs to be used in order for 
-            endpoints to determine whether an offer or answer is associated with an 
+            defined in this specification or an implementation which allocates a new
+            temporary certificate for each association and uses change in fingerprint
+            to indicate new association), other means needs to be used in order for
+            endpoints to determine whether an offer or answer is associated with an
             event that requires the DTLS association to be re-established.
         </t>
         <t>
-            The mux category <xref target="I-D.ietf-mmusic-sdp-mux-attributes"/> 
-            for the 'dtls-connection' attribute is 'IDENTICAL', which means that
+            The mux category <xref target="I-D.ietf-mmusic-sdp-mux-attributes"/>
+            for the 'dtls-association-id' attribute is 'IDENTICAL', which means that
             the attribute value must be identical across all media descriptions
             being multiplexed <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>.
         </t>
         <t>
-            For RTP-based media, the 'dtls-connection' attribute apply to whole associated
+            For RTP-based media, the 'dtls-association-id' attribute apply to whole associated
             media description. The attribute MUST NOT be defined per source (using the
-            SDP 'ssrc' attribute <xref format="default" pageno="false" target="RFC5576"/>). 
+            SDP 'ssrc' attribute <xref format="default" pageno="false" target="RFC5576"/>).
         </t>
         <t>
-            The SDP Offer/Answer <xref format="default" pageno="false" target="RFC3264"/> 
+            The SDP Offer/Answer <xref format="default" pageno="false" target="RFC3264"/>
             procedures associated with the attribute are defined in <xref target="sec-oa"/>
         </t>
     </section>
-    
+
     <section title="SDP Offer/Answer Procedures" anchor="sec-oa">
         <section title="General">
             <t>
                 This section defines the generic SDP offer/answer procedures for negotiating
-                a DTLS association. Additional procedures (e.g. regarding usage of specific SDP 
-                attributes etc) for individual DTLS usages (e.g. SRTP-DTLS) are outside the scope 
+                a DTLS association. Additional procedures (e.g. regarding usage of specific SDP
+                attributes etc) for individual DTLS usages (e.g. SRTP-DTLS) are outside the scope
                 of this specification, and need to be specified in a usage specific specification.
             </t>
             <t>
-                NOTE: The procedures in this section are generalizations of procedures first 
-                specified in SRTP-DTLS <xref format="default" pageno="false" target="RFC5763"/>, 
-                with the addition of usage of the SDP 'dtls-connection' attribute. That document is
+                NOTE: The procedures in this section are generalizations of procedures first
+                specified in SRTP-DTLS <xref format="default" pageno="false" target="RFC5763"/>,
+                with the addition of usage of the SDP 'dtls-association-id' attribute. That document is
                 herein revised to make use of these new procedures.
             </t>
-			<t>
-                The procedures in this section apply to an SDP media description ("m=" line) associated 
-                a DTLS-protected media/data stream.				
-			</t>
-			<t>
+            <t>
+                The procedures in this section apply to an SDP media description ("m=" line) associated
+                a DTLS-protected media/data stream.
+            </t>
+            <t>
                 In order to negotiate a DTLS association, the following SDP attributes are used:
                 <list style="symbols">
                     <t>
-                        The SDP 'setup' attribute, defined in <xref target="RFC4145" pageno="false" 
-                        format="default" />, is used to negotiate the DTLS roles;
+                        The SDP 'setup' attribute, defined in <xref target="RFC4145" pageno="false"
+                        format="default" />, is used to negotiate the DTLS setup roles;
                     </t>
                     <t>
-                        The SDP 'fingerprint' attribute, defined in <xref target="RFC4572" 
-                        pageno="false" format="default" />, is used to provide a fingerprint
-                        value; and
+                        The SDP 'fingerprint' attribute, defined in <xref target="RFC4572"
+                        pageno="false" format="default" />, is used to provide fingerprint
+                        values for the association; and
                     </t>
                     <t>
-                        The SDP 'dtls-connection' attribute, defined in this specification, is
-                        used to explicitly indicate whether a new DTLS association is to be
-                        established or a previous association is to be used.
+                        The SDP 'dtls-association-id' attribute, defined in this specification, is
+                        used to indicate whether a new DTLS association is to be established or a
+                        previous association is to be used if DTLS setup role and fingerprint set
+                        did not change.
                     </t>
                 </list>
-			</t>
-			<t>
-				This specification does not define the usage of the SDP 'connection' attribute 
-				<xref target="RFC4145" pageno="false" format="default" /> for negotiating a DTLS 
-				connection. However, the attribute MAY be used if the DTLS association is used
-				together with another protocol, e.g. SCTP or TCP, for which the usage of the
-				attribute has been defined.				
             </t>
             <t>
-                Unlike for TCP and TLS connections, endpoints MUST NOT use the 
+                This specification does not define the usage of the SDP 'connection' attribute
+                <xref target="RFC4145" pageno="false" format="default" /> for negotiating a DTLS
+                connection. However, the attribute MAY be used if the DTLS association is used
+                together with another protocol, e.g. SCTP or TCP, for which the usage of the
+                attribute has been defined.
+            </t>
+            <t>
+                Unlike for TCP and TLS connections, endpoints MUST NOT use the
                 SDP 'setup' attribute 'holdconn' value when negotiating a DTLS association.
             </t>
             <t>
                 Endpoints MUST support SHA-256 for generating and verifying any fingerprint
-                value associated with the DTLS association. The use of SHA-256 is preferred. 
+                value associated with the DTLS association. The use of SHA-256 is preferred.
             </t>
             <t>
-                Endpoints MUST, at a minimum, support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 
-				and MUST support TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256. UDPTL over DTLS MUST 
-				prefer TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and any other Perfect Forward Secrecy 
-				(PFS) cipher suites over non-PFS cipher suites. Implementations SHOULD disable 
-				TLS-level compression.
-			</t>
-			<t>
-				The certificate received during the DTLS handshake MUST match 
-				a fingerprint received in an SDP "fingerprint" attribute. If a fingerprint 
-				does not match the hashed certificate, then the endpoint MUST tear down the media 
-				session immediately. Note that it is permissible to wait until the other side's 
-				fingerprint has been received before establishing the connection; however, this 
-				may have undesirable latency effects.
-			</t>            
+                The certificate received during the DTLS handshake MUST match one of the fingerprints
+                received in an SDP "fingerprint" attributes. If none of the fingerprints match the 
+                received certificate, then the endpoint MUST tear down the media session immediately.
+                Note that it is permissible to wait until the other side's fingerprints have been received
+                before establishing the connection; however, this may have undesirable latency effects.
+            </t>
         </section>
-        
-        <section title="Generating the Initial SDP Offer">
+
+        <section title="Generating the Initial SDP Offer"  anchor="sec-oa-offer">
             <t>
-                When the offerer sends the initial offer, and the offerer wants to establish a 
-                DTLS association, it MUST insert an SDP 'dtls-connection' attribute with a 'new' value 
-                in the offer. In addition, the offerer MUST insert an SDP 'setup' attribute according 
-                to the procedures in <xref format="default" pageno="false" target="RFC4145"/>, and 
-                one or more SDP 'fingerprint' attributes according to the procedures in <xref format="default" 
-                pageno="false" target="RFC4572"/>, in the offer.
+                When the offerer sends the initial offer, and the offerer wants to establish a
+                DTLS association, it MUST guarantee that combination of fingerprint values and 
+                the SDP 'dtls-association-id' attribute value is unique across all the DTLS associations.
+                If the end point generates a new temporary self signed certificate for each new DTLS association,
+                it can omit the SDP 'dtls-association-id' attribute. If the end point is reusing certificates
+                across multiple DTLS associations, the offer MUST include the SDP 'dtls-association-id' attribute
+                set to a value unique across all the DTLS associations established using these certificates. One 
+                way to generate such unique value for SDP 'dtls-association-id' attribute is to use
+                a random alphanumeric string of sufficient length. If such random string is used for the SDP
+                'dtls-association-id' attribute, in order to avoid collisions, it is recommended to use at
+                least 128 bits of randomness, which means an alphanumeric string at least 25 characters long.
             </t>
             <t>
-                If the offerer inserts the SDP 'setup' attribute with an 'actpass' or 'passive' value, the 
-                offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
+                In addition, the offerer MUST insert an SDP 'setup' attribute set to 'actpass' and one or more SDP
+                'fingerprint' attributes according to the procedures in <xref format="default" pageno="false" target="RFC4572"/>,
+                in the offer.
+            </t>
+            <t>
+                Offerer MUST allocate a new transport for the offer in such a way that it can disambiguate any packets
+                associated with newly established DTLS association from any packets associated with any other DTLS
+                association. This typically means using a local address and or port, or a set of ICE candidates, 
+                if ICE is used, which were not recently used for any other DTLS association.
+            </t>
+            <t>
+                The offerer offerer MUST be prepared to receive a DTLS ClientHello message (if a new DTLS association
                 is established by the answerer) from the answerer before it receives the SDP answer.
             </t>
         </section>
-        <section title="Generating the Answer">       
+        <section title="Generating the Answer">
             <t>
-                If an answerer receives an offer that contains an SDP 'dtls-connection' attribute with a 'new' 
-                value, or if the answerer receives an offer that contains an 'dtls-connection' attribute with an
-                'existing' value and the answerer determines (based on the criteria for establishing 
-                a new DTLS association) that a new DTLS association is to be established, the answerer MUST 
-                insert a 'new' value in the associated answer. In addition, the answerer MUST insert an 
-                SDP 'setup' attribute according to the procedures in <xref format="default" pageno="false" 
-                target="RFC4145"/>, and one or more SDP 'fingerprint' attributes according to the procedures in 
-                <xref format="default" pageno="false" target="RFC4572"/>, in the answer.
+                If an answerer receives an offer that establishes a new SDP session, or an offer in which
+                any of the fingerprint values changed, or any fingerprints where added or removed, or DTLS 
+                setup role changed, or SDP 'dtls-association-id' attribute was added or new value of 
+                SDP 'dtls-association-id' attribute was specified, answerer MUST establish a new DTLS association.
+                If an offer with the same fingerprint values, setup role, and SDP 'dtls-association-id' attribute
+                was received in existing SDP session, answerer can reuse an existing DTLS association or it 
+                can choose to establish a new DTLS association.
             </t>
             <t>
-                If an answerer receives an offer that contains an SDP 'dtls-connection' attribute with a 'new' 
-                value, and if the answerer does not accept the establishment of a new DTLS association, the
-                answerer MUST reject the "m=" lines associated with the suggested DTLS association 
-                <xref format="default" pageno="false" target="RFC3264"/>.
+                If answerer needs to establish a new DTLS association, it MUST guarantee that combination of
+                fingerprint values and the SDP 'dtls-association-id' attribute value is unique across all the
+                DTLS associations. If the end point generates a new temporary self signed certificate for each 
+                new DTLS association, it can omit the SDP 'dtls-association-id' attribute. If the end point is
+                reusing certificates across multiple DTLS associations, the answer MUST include the SDP
+                'dtls-association-id' attribute set to a value unique across all the DTLS associations established
+                using these certificates. One way to generate such unique value for SDP 'dtls-association-id'
+                attribute is to use a random alphanumeric string of sufficient length. If such random string is used 
+                for the SDP 'dtls-association-id' attribute, in order to avoid collisions, it is recommended to use at
+                least 128 bits of randomness, which means an alphanumeric string at least 25 characters long.
             </t>
-            <t>            
-                If an answerer receives an offer that contains a 'dtls-connection' attribute with an 'existing' value, 
+            <t>
+                Furthermore, if answerer needs to establish a new DTLS association, it MUST allocate a new transport
+                for the offer in answer a way that it can disambiguate any packets associated with newly established 
+                DTLS association from any packets associated with any other DTLS association. This typically means
+                using a local address and or port, or a set of ICE candidates, if ICE is used, which were not recently
+                used for any other DTLS association.
+            </t>
+            <t>
+                In addition, the answerer MUST insert an SDP 'setup' attribute according
+                to the procedures in <xref format="default" pageno="false" target="RFC4145"/>, and
+                one or more SDP 'fingerprint' attributes according to the procedures in <xref format="default"
+                pageno="false" target="RFC4572"/>, in the offer.
+            </t>
+            <t>
+                If an answerer receives an offer that requires establishing a new DTLS association, and if the answerer
+                does not accept or incapable the establishment of a new DTLS association, the answerer MUST reject the 
+                "m=" lines associated with the suggested DTLS association <xref format="default" pageno="false" target="RFC3264"/>.
+            </t>
+            <t>
+                If an answerer receives an offer that does not require establishing a new DTLS association,
                 and if the answerer determines that a new DTLS association is not to be established,
-                the answerer MUST insert a 'dtls-connection' attribute with an 'existing' value in the 
-                associated answer. In addition, the answerer MUST insert an SDP 'setup' attribute with a 
-                value that does not change the previously negotiated DTLS roles, and one or more SDP 'fingerprint' 
-                attributes values that do not change the previously sent fingerprints, in the answer.
-            </t>
-            <t>
-                If the answerer receives an offer that does not contain an SDP 'dtls-connection' attribute, 
-                the answerer MUST NOT insert a 'dtls-connection' attribute in the answer.
+                the answerer MUST insert the SDP 'dtls-association-id' attribute and fingerprint values
+                set to the same values as previously sent values for these attributes, and the SDP 'setup' attribute
+                set to the previously negotiated role for this DTLS association, in the answer.
             </t>
             <t>
                 If a new DTLS association is to be established, and if the answerer inserts an SDP 'setup'
@@ -320,22 +352,22 @@
         </section>
         <section title="Offerer Processing of the SDP Answer">
             <t>
-                When an offerer receives an answer that contains an SDP 'dtls-connection' attribute with 
-                a 'new' value, and if the offerer becomes DTLS client (based on the value of the SDP 'setup'
-                attribute value <xref format="default" pageno="false" target="RFC4145"/>), the offerer MUST 
-                establish a DTLS association. If the offerer becomes DTLS server, it MUST wait for the answerer 
-                to establish the DTLS association.
+                If an offerer sends an offer or receives an answer which indicate a start of a new DTLS
+                association by any changes in fingerprint values, changed SDP 'dtls-association-id' attribute,
+                or change in negotiated DTLS setup role, a new DTLS association MUST be established.
+                If the offerer becomes DTLS client (based on the  value of the SDP 'setup' attribute value
+                <xref format="default" pageno="false" target="RFC4145"/>), the offerer MUST establish a DTLS
+                association. If the offerer becomes DTLS server, it MUST wait for the answerer to establish
+                the DTLS association.
             </t>
             <t>
-                If the answer contains an SDP 'dtls-connection' attribute with an 'existing' value, the offerer 
-                will continue using the previously established DTLS association. It is considered an error 
-                case if the answer contains a 'dtls-connection' attribute with an 'existing' value, and a DTLS 
-                association does not exist.
+                If none of the fingerprint values, SDP 'dtls-association-id' attribute, or negotiated DTLS setup
+                role changed, offerer will continue using the previously established DTLS association.
             </t>
             <t>
                 An offerer needs to be able to handle error conditions that can occur during an offer/answer
-                transaction, e.g. if an answer contains an SDP 'dtls-connection' attribute with an 'existing' value even
-                if no DTLS association exists, or if the answer contains one or more new fingerprint values for an existing DTLS association. 
+                transaction, e.g. if the answer contains changed fingerprint values or new value for the 
+                SDP 'dtls-association-id' attribute without the transport change (same transport 5-tuple or same ICE session).
                 If such error case occurs, the offerer SHOULD terminate the associated DTLS association (if it exists) and send
                 a new offer in order to terminate each media stream using the DTLS association, by setting the associated
                 port value to zero <xref format="default" pageno="false" target="RFC4145"/>.
@@ -343,28 +375,29 @@
         </section>
         <section title="Modifying the Session">
             <t>
-                When the offerer sends a subsequent offer, and if the offerer wants to establish a new 
-                DTLS association, the offerer MUST insert an SDP 'dtls-connection' attribute with a 'new' 
-                value in the offer. In addition, the offerer MUST insert an SDP 'setup' attribute 
-                according to the procedures in <xref format="default" pageno="false" target="RFC4145"/>, 
-                and one or more SDP 'fingerprint' attributes according to the procedures in <xref format="default" 
-                pageno="false" target="RFC4572"/>, in the offer.
-             </t>
+                When the offerer sends a subsequent offer, and if the offerer wants to establish a new
+                DTLS association, the offerer MUST guarantee that combination of fingerprint values and 
+                the SDP 'dtls-association-id' attribute value is unique across all the DTLS associations.
+                In addition, the offerer MUST insert an SDP 'setup' attribute set to 'actpass', and one or more
+                SDP 'fingerprint' attributes according to the procedures in <xref format="default" pageno="false"
+                target="RFC4572"/>, in the offer. Furthermore, offerer MUST allocate a new transport for the offer
+                in such a way that it can disambiguate any packets associated with newly established DTLS association
+                from any packets associated with any other DTLS association.
+            </t>
              <t>
-                when the offerer sends a subsequent offer, and the offerer does not want to establish
-                a new DTLS association, and if a previously established DTLS association exists, the 
-                offerer MUST insert an SDP 'dtls-connection' attribute with an 'existing' value in the offer. 
-                In addition, the offerer MUST insert an SDP 'setup' attribute with a value that does 
-                not change the previously negotiated DTLS roles, and one or more SDP 'fingerprint' attributes with 
-                values that do not change the previously sent fingerprints, in the offer.
+                When the offerer sends a subsequent offer, and the offerer does not want to establish
+                a new DTLS association, and if a previously established DTLS association exists, the
+                offerer MUST insert the SDP 'dtls-association-id' attribute and fingerprint values
+                set to the same values as previously sent values for these attributes, and the SDP 'setup'
+                attribute set to the previously negotiated role for this DTLS association, in the answer.
             </t>
             <t>
-                NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive 
+                NOTE: When a new DTLS association is established, each endpoint needs to be prepared to receive
                 data on both the new and old DTLS associations as long as both are alive.
             </t>
         </section>
-	</section>
-    
+    </section>
+
     <section title="ICE Considerations" anchor="sec-dtls-reest-ice">
         <t>
             When ICE is used, the ICE connectivity checks are performed before the DTLS
@@ -373,50 +406,76 @@
             converges on a single candidate pair.
         </t>
         <t>
-            An ICE restart <xref format="default" pageno="false" target="RFC5245"/> 
-            does not by default require a new DTLS association to be established.             
+            An ICE restart <xref format="default" pageno="false" target="RFC5245"/>
+            does not by default require a new DTLS association to be established.
         </t>
         <t>
-            As defined in <xref format="default" pageno="false" target="RFC5763"/>, 
-            each ICE candidate associated with a component is treated as being part of the 
-            same DTLS association. Therefore, from a DTLS perspective it is not considered 
-            a change of local transport parameters when an endpoint switches between those 
+            As defined in <xref format="default" pageno="false" target="RFC5763"/>,
+            each ICE candidate associated with a component is treated as being part of the
+            same DTLS association. Therefore, from a DTLS perspective it is not considered
+            a change of local transport parameters when an endpoint switches between those
             ICE candidates.
         </t>
+        <t>
+            When new DTLS association is established, in order to disambiguate any packets
+            associated with newly established DTLS association, at least one of the end
+            points MUST allocate a completely new set of ICE candidates which were not recently
+            used for any other DTLS association. This also means that answerer cannot
+            initiate a new DTLS association unless offerer initiated ICE restart.
+        </t>
+        <t>
+            Note that Simple Traversal of the UDP Protocol through NAT (STUN)
+            packets are sent directly over UDP, not over DTLS.  [RFC5764]
+            describes how to demultiplex STUN packets from DTLS packets and SRTP
+            packets.
+        </t>
     </section>
-    
+
     <section title="Transport Protocol Considerations" anchor="sec-dtls-cons-trans">
         <section title="Transport Re-Usage" anchor="sec-dtls-cons-trans-reuse">
             <t>
-                If DTLS is transported on top of a connection-oriented transport protocol (e.g. TCP or SCTP),
-                where all IP packets are acknowledged, all DTLS packets associated with a previous
+                If DTLS is transported on top of a reliable transport protocol (e.g. TCP or SCTP),
+                where all IP packets are acknowledged, multiple DTLS associations can
+                reuse the same transport protocol. All DTLS packets associated with a previous
                 DTLS association MUST be acknowledged (or timed out) before a new DTLS association
                 can be established on the same transport.
             </t>
         </section>
+        <section title="Spanning Multiple Transport" anchor="sec-dtls-cons-trans-span">
+            <t>
+                Unless explicitly prohibited by underlying transport DTLS association 
+                can span across transport changes. If fingerprints, SDP 'dtls-association-id',
+                and negotiated role remain the same, exisitng DTLS association continues
+                even if underlying transport 5-tuple changes or ICE session is restarted.
+            </t>
+        </section>
     </section>
-    
+
     <section title="SIP Considerations">
         <t>
-            When the Session Initiation Protocol (SIP) <xref format="default" pageno="false" 
-            target="RFC3261"/> is used as the signal protocol for establishing a multimedia 
-            session, dialogs <xref format="default" pageno="false" target="RFC3261"/> might be 
-            established between the caller and multiple callees. This is referred to as forking. 
-            If forking occurs, separate DTLS associations MUST be established between the caller 
+            When the Session Initiation Protocol (SIP) <xref format="default" pageno="false"
+            target="RFC3261"/> is used as the signal protocol for establishing a multimedia
+            session, dialogs <xref format="default" pageno="false" target="RFC3261"/> might be
+            established between the caller and multiple callees. This is referred to as forking.
+            If forking occurs, separate DTLS associations MUST be established between the caller
             and each callee.
         </t>
-		<t>
-            It is possible to send an INVITE request which does not contain an SDP offer. Such 
-            INVITE request is often referred to as an 'empty INVITE', or an 'offerless INVITE'. 
-            The receiving endpoint will include the SDP offer in a response associated with the 
-            response. When the endpoint generates such SDP offer, it MUST assign an SDP 'dtls-connection' 
-            attribute, with a 'new' value, to each 'm-' line that describes DTLS protected media. 
-            If ICE is used, the endpoint MUST allocate a new set of ICE candidates, in order to 
-            ensure that two DTLS association would not be running over the same transport.
+        <t>
+            It is possible to send an INVITE request which does not contain an SDP offer. Such
+            INVITE request is often referred to as an 'empty INVITE', or an 'offerless INVITE'.
+            The receiving endpoint will include the SDP offer in a response associated with the
+            response. When the endpoint generates such SDP offer, if a previously established
+            DTLS association exists, the offerer SHOULD insert the SDP 'dtls-association-id' 
+            attribute and fingerprint values set to the same values as previously sent values
+            for these attributes. If a previously established DTLS association did not exists 
+            offer SHOULD be generated based on the same rules as new offer <xref target="sec-oa-offer"/>.
+            Regardless of the previous existence of DTLS association, the SDP 'setup' attribute 
+            MUST be set to 'actpass' and if ICE is used, ICE restart MUST be initiated as defined in
+            <xref format="default" pageno="false" target="RFC5763"/>.
         </t>
-	</section>
+    </section>
 
-    
+
     <section title="RFC Updates">
         <section title="General">
             <t>
@@ -425,484 +484,226 @@
             </t>
         </section>
         <section title="Update to RFC 5763">
-            <figure>
-                <artwork align="left" alt="" height="" name="" type="" width="" xml:space="preserve"><![CDATA[
-
-Update to section 5:
---------------------                
-
-OLD TEXT:
-
-5.  Establishing a Secure Channel
-
-   The two endpoints in the exchange present their identities as part of
-   the DTLS handshake procedure using certificates.  This document uses
-   certificates in the same style as described in "Connection-Oriented
-   Media Transport over the Transport Layer Security (TLS) Protocol in
-   the Session Description Protocol (SDP)" [RFC4572].
-
-   If self-signed certificates are used, the content of the
-   subjectAltName attribute inside the certificate MAY use the uniform
-   resource identifier (URI) of the user.  This is useful for debugging
-   purposes only and is not required to bind the certificate to one of
-   the communication endpoints.  The integrity of the certificate is
-   ensured through the fingerprint attribute in the SDP.  The
-   subjectAltName is not an important component of the certificate
-   verification.
-
-   The generation of public/private key pairs is relatively expensive.
-   Endpoints are not required to generate certificates for each session.
-
-   The offer/answer model, defined in [RFC3264], is used by protocols
-   like the Session Initiation Protocol (SIP) [RFC3261] to set up
-   multimedia sessions.  In addition to the usual contents of an SDP
-   [RFC4566] message, each media description ("m=" line and associated
-   parameters) will also contain several attributes as specified in
-   [RFC5764], [RFC4145], and [RFC4572].
-
-   When an endpoint wishes to set up a secure media session with another
-   endpoint, it sends an offer in a SIP message to the other endpoint.
-   This offer includes, as part of the SDP payload, the fingerprint of
-   the certificate that the endpoint wants to use.  The endpoint SHOULD
-   send the SIP message containing the offer to the offerer's SIP proxy
-   over an integrity protected channel.  The proxy SHOULD add an
-   Identity header field according to the procedures outlined in
-   [RFC4474].  The SIP message containing the offer SHOULD be sent to
-   the offerer's SIP proxy over an integrity protected channel.  When
-   the far endpoint receives the SIP message, it can verify the identity
-   of the sender using the Identity header field.  Since the Identity
-   header field is a digital signature across several SIP header fields,
-   in addition to the body of the SIP message, the receiver can also be
-   certain that the message has not been tampered with after the digital
-   signature was applied and added to the SIP message.
-
-   The far endpoint (answerer) may now establish a DTLS association with
-   the offerer.  Alternately, it can indicate in its answer that the
-   offerer is to initiate the TLS association.  In either case, mutual
-   DTLS certificate-based authentication will be used.  After completing
-   the DTLS handshake, information about the authenticated identities,
-   including the certificates, are made available to the endpoint
-   application.  The answerer is then able to verify that the offerer's
-   certificate used for authentication in the DTLS handshake can be
-   associated to the certificate fingerprint contained in the offer in
-   the SDP.  At this point, the answerer may indicate to the end user
-   that the media is secured.  The offerer may only tentatively accept
-   the answerer's certificate since it may not yet have the answerer's
-   certificate fingerprint.
-
-   When the answerer accepts the offer, it provides an answer back to
-   the offerer containing the answerer's certificate fingerprint.  At
-   this point, the offerer can accept or reject the peer's certificate
-   and the offerer can indicate to the end user that the media is
-   secured.
-
-   Note that the entire authentication and key exchange for securing the
-   media traffic is handled in the media path through DTLS.  The
-   signaling path is only used to verify the peers' certificate
-   fingerprints.
-
-   The offer and answer MUST conform to the following requirements.
-
-   o  The endpoint MUST use the setup attribute defined in [RFC4145].
-      The endpoint that is the offerer MUST use the setup attribute
-      value of setup:actpass and be prepared to receive a client_hello
-      before it receives the answer.  The answerer MUST use either a
-      setup attribute value of setup:active or setup:passive.  Note that
-      if the answerer uses setup:passive, then the DTLS handshake will
-      not begin until the answerer is received, which adds additional
-      latency. setup:active allows the answer and the DTLS handshake to
-      occur in parallel.  Thus, setup:active is RECOMMENDED.  Whichever
-      party is active MUST initiate a DTLS handshake by sending a
-      ClientHello over each flow (host/port quartet).
-
-   o  The endpoint MUST NOT use the connection attribute defined in
-      [RFC4145].
-
-   o  The endpoint MUST use the certificate fingerprint attribute as
-      specified in [RFC4572].
-
-   o  The certificate presented during the DTLS handshake MUST match the
-      fingerprint exchanged via the signaling path in the SDP.  The
-      security properties of this mechanism are described in Section 8.
-
-   o  If the fingerprint does not match the hashed certificate, then the
-      endpoint MUST tear down the media session immediately.  Note that
-      it is permissible to wait until the other side's fingerprint has
-      been received before establishing the connection; however, this
-      may have undesirable latency effects.
-
-   
-NEW TEXT:
-
-5.  Establishing a Secure Channel
-
-   The two endpoints in the exchange present their identities as part of
-   the DTLS handshake procedure using certificates.  This document uses
-   certificates in the same style as described in "Connection-Oriented
-   Media Transport over the Transport Layer Security (TLS) Protocol in
-   the Session Description Protocol (SDP)" [RFC4572].
-
-   If self-signed certificates are used, the content of the
-   subjectAltName attribute inside the certificate MAY use the uniform
-   resource identifier (URI) of the user.  This is useful for debugging
-   purposes only and is not required to bind the certificate to one of
-   the communication endpoints.  The integrity of the certificate is
-   ensured through the fingerprint attribute in the SDP.
-
-   The generation of public/private key pairs is relatively expensive.
-   Endpoints are not required to generate certificates for each session.
-
-   The offer/answer model, defined in [RFC3264], is used by protocols
-   like the Session Initiation Protocol (SIP) [RFC3261] to set up
-   multimedia sessions.
-   
-   When an endpoint wishes to set up a secure media session with another
-   endpoint, it sends an offer in a SIP message to the other endpoint.
-   This offer includes, as part of the SDP payload, a fingerprint of
-   a certificate that the endpoint wants to use.  The endpoint SHOULD
-   send the SIP message containing the offer to the offerer's SIP proxy
-   over an integrity protected channel.  The proxy SHOULD add an
-   Identity header field according to the procedures outlined in
-   [RFC4474].  The SIP message containing the offer SHOULD be sent to
-   the offerer's SIP proxy over an integrity protected channel.  When
-   the far endpoint receives the SIP message, it can verify the identity
-   of the sender using the Identity header field.  Since the Identity
-   header field is a digital signature across several SIP header fields,
-   in addition to the body of the SIP message, the receiver can also be
-   certain that the message has not been tampered with after the digital
-   signature was applied and added to the SIP message.
-
-   The far endpoint (answerer) may now establish a DTLS association with
-   the offerer.  Alternately, it can indicate in its answer that the
-   offerer is to initiate the DTLS association.  In either case, mutual
-   DTLS certificate-based authentication will be used.  After completing
-   the DTLS handshake, information about the authenticated identities,
-   including the certificates, are made available to the endpoint
-   application.  The answerer is then able to verify that the offerer's
-   certificate used for authentication in the DTLS handshake can be
-   associated to the certificate fingerprint contained in the offer in
-   the SDP.  At this point, the answerer may indicate to the end user
-   that the media is secured.  The offerer may only tentatively accept
-   the answerer's certificate since it may not yet have the answerer's
-   certificate fingerprint.
-
-   When the answerer accepts the offer, it provides an answer back to
-   the offerer containing the answerer's certificate fingerprint.  At
-   this point, the offerer can accept or reject the peer's certificate
-   and the offerer can indicate to the end user that the media is
-   secured.
-
-   Note that the entire authentication and key exchange for securing the
-   media traffic is handled in the media path through DTLS.  The
-   signaling path is only used to verify the peers' certificate
-   fingerprints.
-
-   The offerer and answerer MUST follow the SDP offer/answer procedures 
-   defined in [RFCXXXX].
-   
-      
-Update to section 6.6:
-----------------------
-
-OLD TEXT:
-
-6.6.  Session Modification
-
-   Once an answer is provided to the offerer, either endpoint MAY
-   request a session modification that MAY include an updated offer.
-   This session modification can be carried in either an INVITE or
-   UPDATE request.  The peers can reuse the existing associations if
-   they are compatible (i.e., they have the same key fingerprints and
-   transport parameters), or establish a new one following the same
-   rules are for initial exchanges, tearing down the existing
-   association as soon as the offer/answer exchange is completed.  Note
-   that if the active/passive status of the endpoints changes, a new
-   connection MUST be established.
- 
-NEW TEXT:
-
-6.6.  Session Modification
-
-   Once an answer is provided to the offerer, either endpoint MAY
-   request a session modification that MAY include an updated offer.
-   This session modification can be carried in either an INVITE or
-   UPDATE request. The peers can reuse an existing DTLS association, 
-   or establish a new one, following the procedures in [RFCXXXX].
-
-Update to section 6.7.1:
-------------------------
-
-OLD TEXT:
-
-6.7.1.  ICE Interaction
-
-   Interactive Connectivity Establishment (ICE), as specified in
-   [RFC5245], provides a methodology of allowing participants in
-   multimedia sessions to verify mutual connectivity.  When ICE is being
-   used, the ICE connectivity checks are performed before the DTLS
-   handshake begins.  Note that if aggressive nomination mode is used,
-   multiple candidate pairs may be marked valid before ICE finally
-   converges on a single candidate pair.  Implementations MUST treat all
-   ICE candidate pairs associated with a single component as part of the
-   same DTLS association.  Thus, there will be only one DTLS handshake
-   even if there are multiple valid candidate pairs.  Note that this may
-   mean adjusting the endpoint IP addresses if the selected candidate
-   pair shifts, just as if the DTLS packets were an ordinary media
-   stream.
-
-   Note that Simple Traversal of the UDP Protocol through NAT (STUN)
-   packets are sent directly over UDP, not over DTLS.  [RFC5764]
-   describes how to demultiplex STUN packets from DTLS packets and SRTP
-   packets.
-
-NEW TEXT:
-
-6.7.1.  ICE Interaction
-
-   The Interactive Connectivity Establishment (ICE) [RFC5245]
-   considerations for DTLS-protected media are described in
-   [RFCXXXX].
-
-   Note that Simple Traversal of the UDP Protocol through NAT (STUN)
-   packets are sent directly over UDP, not over DTLS.  [RFC5764]
-   describes how to demultiplex STUN packets from DTLS packets and SRTP
-   packets.
-   
-                ]]></artwork>
-            </figure>
+            <section title="Update to Section 5. Establishing a Secure Channel">
+                <t>
+                    This section is updated to clarify the procedure for matching multiple fingerprints
+                    and to modify the offer/answer procedures based on the rules provided in this specification.
+                </t>
+                <t>
+                   The two endpoints in the exchange present their identities as part of
+                   the DTLS handshake procedure using certificates.  This document uses
+                   certificates in the same style as described in "Connection-Oriented
+                   Media Transport over the Transport Layer Security (TLS) Protocol in
+                   the Session Description Protocol (SDP)" [RFC4572].
+                </t>
+                <t>
+                   If self-signed certificates are used, the content of the
+                   subjectAltName attribute inside the certificate MAY use the uniform
+                   resource identifier (URI) of the user.  This is useful for debugging
+                   purposes only and is not required to bind the certificate to one of
+                   the communication endpoints.  The integrity of the certificate is
+                   ensured through the fingerprint attribute in the SDP.
+                </t>
+                <t>
+                   The generation of public/private key pairs is relatively expensive.
+                   Endpoints are not required to generate certificates for each session.
+                </t>
+                <t>
+                   The offer/answer model, defined in [RFC3264], is used by protocols
+                   like the Session Initiation Protocol (SIP) [RFC3261] to set up
+                   multimedia sessions.
+                </t>
+                <t>
+                   When an endpoint wishes to set up a secure media session with another
+                   endpoint, it sends an offer in a SIP message to the other endpoint.
+                   This offer includes, as part of the SDP payload, a set fingerprints for
+                   for one or more certificate that the endpoint can use.  The endpoint SHOULD
+                   send the SIP message containing the offer to the offerer's SIP proxy
+                   over an integrity protected channel.  The proxy SHOULD add an
+                   Identity header field according to the procedures outlined in
+                   [RFC4474].  The SIP message containing the offer SHOULD be sent to
+                   the offerer's SIP proxy over an integrity protected channel.  When
+                   the far endpoint receives the SIP message, it can verify the identity
+                   of the sender using the Identity header field.  Since the Identity
+                   header field is a digital signature across several SIP header fields,
+                   in addition to the body of the SIP message, the receiver can also be
+                   certain that the message has not been tampered with after the digital
+                   signature was applied and added to the SIP message.
+                </t>
+                <t>
+                   The far endpoint (answerer) may now establish a DTLS association with
+                   the offerer.  Alternately, it can indicate in its answer that the
+                   offerer is to initiate the DTLS association.  In either case, mutual
+                   DTLS certificate-based authentication will be used.  After completing
+                   the DTLS handshake, information about the authenticated identities,
+                   including the certificates, are made available to the endpoint
+                   application.  The answerer is then able to verify that the offerer's
+                   certificate used for authentication in the DTLS handshake can be
+                   associated to any of the certificate fingerprints contained in the offer in
+                   the SDP.  At this point, the answerer may indicate to the end user
+                   that the media is secured.  The offerer may only tentatively accept
+                   the answerer's certificate since it may not yet have the fingerprints
+                   for answerer certificates.
+                </t>
+                <t>
+                   When the answerer accepts the offer, it provides an answer back to
+                   the offerer containing fingerprints the answerer's certificates.  At
+                   this point, the offerer can accept or reject the peer's certificate
+                   and the offerer can indicate to the end user that the media is
+                   secured.
+                </t>
+                <t>
+                   Note that the entire authentication and key exchange for securing the
+                   media traffic is handled in the media path through DTLS.  The
+                   signaling path is only used to verify the peers' certificate
+                   fingerprints.
+                </t>
+                <t>
+                   The offerer and answerer MUST follow the SDP offer/answer procedures
+                   defined in [RFCXXXX].
+                </t>
+            </section>
+            <section title="Update to Section 6.6. Session Modification">
+                <t>
+                    This section is updated to use offer/answer procedures based on the rules provided
+                    in this specification.
+                </t>
+                <t>
+                   Once an answer is provided to the offerer, either endpoint MAY
+                   request a session modification that MAY include an updated offer.
+                   This session modification can be carried in either an INVITE or
+                   UPDATE request. The peers can reuse an existing DTLS association,
+                   or establish a new one, following the procedures in [RFCXXXX].
+                </t>
+            </section>
+            <section title="Update to Section 6.7.1. ICE Interaction">
+                <t>
+                    This section is updated to use ICE related rules provided
+                    in this specification.
+                </t>
+                <t>
+                   The Interactive Connectivity Establishment (ICE) [RFC5245]
+                   considerations for DTLS-protected media are described in
+                   [RFCXXXX].
+                </t>
+            </section>
         </section>
         <section title="Update to RFC 7345">
-            <figure>
-                <artwork align="left" alt="" height="" name="" type="" width="" xml:space="preserve"><![CDATA[
-
-Update to section 4:
---------------------
-                
-OLD TEXT:
-
-4.  SDP Offerer/Answerer Procedures
-
-4.1.  General
-
-   An endpoint (i.e., both the offerer and the answerer) MUST create an
-   SDP media description ("m=" line) for each UDPTL-over-DTLS media
-   stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
-   "proto" field of the "m=" line.
-
-   The procedures in this section apply to an "m=" line associated with
-   a UDPTL-over-DTLS media stream.
-
-   In order to negotiate a UDPTL-over-DTLS media stream, the following
-   SDP attributes are used:
-
-   o  The SDP attributes defined for UDPTL over UDP, as described in
-      [ITU.T38.2010]; and
-
-   o  The SDP attributes, defined in [RFC4145] and [RFC4572], as
-      described in this section.
-
-   The endpoint MUST NOT use the SDP "connection" attribute [RFC4145].
-
-   In order to negotiate the TLS roles for the UDPTL-over-DTLS transport
-   connection, the endpoint MUST use the SDP "setup" attribute
-   [RFC4145].
-
-   If the endpoint supports, and is willing to use, a cipher suite with
-   an associated certificate, the endpoint MUST include an SDP
-   "fingerprint" attribute [RFC4572].  The endpoint MUST support SHA-256
-   for generating and verifying the SDP "fingerprint" attribute value.
-   The use of SHA-256 is preferred.  UDPTL over DTLS, at a minimum, MUST
-   support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 and MUST support
-   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.  UDPTL over DTLS MUST prefer
-   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 and any other Perfect Forward
-   Secrecy (PFS) cipher suites over non-PFS cipher suites.
-   Implementations SHOULD disable TLS-level compression.
-
-   If a cipher suite with an associated certificate is selected during
-   the DTLS handshake, the certificate received during the DTLS
-   handshake MUST match the fingerprint received in the SDP
-   "fingerprint" attribute.  If the fingerprint does not match the
-   hashed certificate, then the endpoint MUST tear down the media
-   session immediately.  Note that it is permissible to wait until the
-   other side's fingerprint has been received before establishing the
-   connection; however, this may have undesirable latency effects.
-
-4.2.  Generating the Initial Offer
-
-   The offerer SHOULD assign the SDP "setup" attribute with a value of
-   "actpass", unless the offerer insists on being either the sender or
-   receiver of the DTLS ClientHello message, in which case the offerer
-   can use either a value of "active" (the offerer will be the sender of
-   ClientHello) or "passive" (the offerer will be the receiver of
-   ClientHello).  The offerer MUST NOT assign an SDP "setup" attribute
-   with a "holdconn" value.
-
-   If the offerer assigns the SDP "setup" attribute with a value of
-   "actpass" or "passive", the offerer MUST be prepared to receive a
-   DTLS ClientHello message before it receives the SDP answer.
-
-4.3.  Generating the Answer
-
-   If the answerer accepts the offered UDPTL-over-DTLS transport
-   connection, in the associated SDP answer, the answerer MUST assign an
-   SDP "setup" attribute with a value of either "active" or "passive",
-   according to the procedures in [RFC4145].  The answerer MUST NOT
-   assign an SDP "setup" attribute with a value of "holdconn".
-
-   If the answerer assigns an SDP "setup" attribute with a value of
-   "active" value, the answerer MUST initiate a DTLS handshake by
-   sending a DTLS ClientHello message on the negotiated media stream,
-   towards the IP address and port of the offerer.
-
-4.4.  Offerer Processing of the Answer
-
-   When the offerer receives an SDP answer, if the offerer ends up being
-   active it MUST initiate a DTLS handshake by sending a DTLS
-   ClientHello message on the negotiated media stream, towards the IP
-   address and port of the answerer.
-
-4.5.  Modifying the Session
-
-   Once an offer/answer exchange has been completed, either endpoint MAY
-   send a new offer in order to modify the session.  The endpoints can
-   reuse the existing DTLS association if the key fingerprint values and
-   transport parameters indicated by each endpoint are unchanged.
-   Otherwise, following the rules for the initial offer/answer exchange,
-   the endpoints can negotiate and create a new DTLS association and,
-   once created, delete the previous DTLS association, following the
-   same rules for the initial offer/answer exchange.  Each endpoint
-   needs to be prepared to receive data on both the new and old DTLS
-   associations as long as both are alive.
-   
-NEW TEXT:
-
-4.  SDP Offerer/Answerer Procedures
-
-   An endpoint (i.e., both the offerer and the answerer) MUST create an
-   SDP media description ("m=" line) for each UDPTL-over-DTLS media
-   stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
-   "proto" field of the "m=" line.
-
-   The offerer and answerer MUST follow the SDP offer/answer procedures
-   defined in [RFCXXXX] in order to negotiate the DTLS association
-   associated with the UDPTL-over-DTLS media stream. In addition,
-   the offerer and answerer MUST use the SDP attributes defined for
-   UDPTL over UDP, as defined in [ITU.T38.2010].
-
-
-Update to section 5.2.1:
-------------------------
-
-OLD TEXT:
-   
-5.2.1.  ICE Usage
-
-   When Interactive Connectivity Establishment (ICE) [RFC5245] is being
-   used, the ICE connectivity checks are performed before the DTLS
-   handshake begins.  Note that if aggressive nomination mode is used,
-   multiple candidate pairs may be marked valid before ICE finally
-   converges on a single candidate pair.  User Agents (UAs) MUST treat
-   all ICE candidate pairs associated with a single component as part of
-   the same DTLS association.  Thus, there will be only one DTLS
-   handshake even if there are multiple valid candidate pairs.  Note
-   that this may mean adjusting the endpoint IP addresses if the
-   selected candidate pair shifts, just as if the DTLS packets were an
-   ordinary media stream.  In the case of an ICE restart, the DTLS
-   handshake procedure is repeated, and a new DTLS association is
-   created.  Once the DTLS handshake is completed and the new DTLS
-   association has been created, the previous DTLS association is
-   deleted.
-
-   
-NEW TEXT:
-   
-5.2.1.  ICE Usage
-
-   The Interactive Connectivity Establishment (ICE) [RFC5245]
-   considerations for DTLS-protected media are described in
-   [RFCXXXX].
-
-                ]]></artwork>
-            </figure>
+            <section title="Update to Section 4. SDP Offerer/Answerer Procedures">
+                <t>
+                    This section is updated to use offer/answer rules provided
+                    in this specification.
+                </t>
+                <t>
+                    An endpoint (i.e., both the offerer and the answerer) MUST create an
+                    SDP media description ("m=" line) for each UDPTL-over-DTLS media
+                    stream and MUST assign a UDP/TLS/UDPTL value (see Table 1) to the
+                    "proto" field of the "m=" line.
+                </t>
+                <t>
+                    The offerer and answerer MUST follow the SDP offer/answer procedures
+                    defined in [RFCXXXX] in order to negotiate the DTLS association
+                    associated with the UDPTL-over-DTLS media stream. In addition,
+                    the offerer and answerer MUST use the SDP attributes defined for
+                    UDPTL over UDP, as defined in [ITU.T38.2010].
+                </t>
+            </section>
+            <section title="Update to Section 5.2.1. ICE Usage">
+                <t>
+                    This section is updated to use ICE related rules provided
+                    in this specification.
+                </t>
+                <t>
+                   The Interactive Connectivity Establishment (ICE) [RFC5245]
+                   considerations for DTLS-protected media are described in
+                   [RFCXXXX].
+                </t>
+            </section>
         </section>
-	</section>
-    
-	<section title="Security Considerations">
-		<t>
-			This specification does not modify the security considerations associated with DTLS, or
+    </section>
+
+    <section title="Security Considerations">
+        <t>
+            This specification does not modify the security considerations associated with DTLS, or
             the SDP offer/answer mechanism. In addition to the introduction of the SDP
             'dtls-connection' attribute, the specification simply clarifies the procedures for
             negotiating and establishing a DTLS association.
-		</t>
-	</section>
-	
-	<section anchor="section.iana" title="IANA Considerations">
+        </t>
+    </section>
+
+    <section anchor="section.iana" title="IANA Considerations">
         <t>
-            This document updates the "Session Description Protocol Parameters" registry 
+            This document updates the "Session Description Protocol Parameters" registry
             as specified in Section 8.2.2 of <xref target="RFC4566" pageno="false" format="default"/>.
-            Specifically, it adds the SDP dtls-connection attribute to the table for SDP 
+            Specifically, it adds the SDP dtls-association-id attribute to the table for SDP
             media level attributes.
         </t>
         <figure>
-			<artwork align="left"><![CDATA[
+            <artwork align="left"><![CDATA[
 
-    Attribute name: dtls-connection
+    Attribute name: dtls-association-id
     Type of attribute: media-level
     Subject to charset: no
     Purpose: Indicate whether a new DTLS association is to be established/re-established.
     Appropriate Values: see Section 4
     Contact name: Christer Holmberg
     Category: IDENTICAL
-    
-			]]></artwork>
-		</figure>        
-	</section>
-                   
-	<section title="Acknowledgements">
-		<t>
+
+            ]]></artwork>
+        </figure>
+    </section>
+
+    <section title="Acknowledgements">
+        <t>
             Thanks to Justin Uberti, Martin Thomson, Paul Kyzivat, Jens Guballa,
-            Charles Eckel and Gonzalo Salgueiro for providing comments and 
+            Charles Eckel and Gonzalo Salgueiro for providing comments and
             suggestions on the draft.
         </t>
-	</section>
-		
-	<section title="Change Log">	
-		<t>[RFC EDITOR NOTE: Please remove this section when publishing]</t>
+    </section>
+
+    <section title="Change Log">
+        <t>[RFC EDITOR NOTE: Please remove this section when publishing]</t>
+        <t>Changes from draft-ietf-mmusic-sdp-dtls-11
+            <list style="symbols">
+                <t>Modified document to use dtls-association-id instead of dtls-connection</t>
+                <t>Changes are based on comments from Eric Rescorla, Justin Uberti, and Paul Kyzivat.</t>
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-08
-			<list style="symbols">
+            <list style="symbols">
                 <t>Offer/Answer section modified in order to allow sending of multiple SDP 'fingerprint' attributes.</t>
                 <t>Terminology made consistent: 'DTLS connection' replaced with 'DTLS association'.</t>
                 <t>Editorial changes based on comments from Paul Kyzivat.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-07
-			<list style="symbols">
+            <list style="symbols">
                 <t>Reference to RFC 7315 replaced with reference to RFC 7345.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-06
-			<list style="symbols">
+            <list style="symbols">
                 <t>Text on restrictions regarding spanning a DTLS association over multiple transports added.</t>
                 <t>Mux category added to IANA Considerations.</t>
                 <t>Normative text regarding mux category and source-specific applicability added.</t>
                 <t>Reference to RFC 7315 added.</t>
                 <t>Clarified that offerer/answerer that has not been updated to support this specification will
                 not include the dtls-connection attribute in offers and answers.</t>
-				<t>Editorial corrections based on WGLC comments from Charles Eckel.</t>
-			</list>
-		</t>		
+                <t>Editorial corrections based on WGLC comments from Charles Eckel.</t>
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-05
-			<list style="symbols">
+            <list style="symbols">
                 <t>Text on handling offer/answer error conditions added.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-04
-			<list style="symbols">
+            <list style="symbols">
                 <t>Editorial nits fixed based on comments from Paul Kyzivat:</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-03
-			<list style="symbols">
+            <list style="symbols">
                 <t>Changes based on comments from Paul Kyzivat:</t>
                 <t>- Modification of dtls-connection attribute section.</t>
                 <t>- Removal of IANA considerations subsection.</t>
@@ -910,51 +711,51 @@ NEW TEXT:
                 <t>Changes based on comments from Martin Thompson:</t>
                 <t>- Abbreviations section removed.</t>
                 <t>- Clarify that a new DTLS association requires a new o/a transaction.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-02
-			<list style="symbols">
+            <list style="symbols">
                 <t>- Updated RFCs added to boilerplate.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-01
-			<list style="symbols">
+            <list style="symbols">
                 <t>- Annex regarding 'dtls-connection-id' attribute removed.</t>
                 <t>- Additional SDP offer/answer procedures, related to certificates, added.</t>
                 <t>- Updates to RFC 5763 and RFC 7345 added.</t>
                 <t>- Transport protocol considerations added.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-ietf-mmusic-sdp-dtls-00
-			<list style="symbols">
+            <list style="symbols">
                 <t>- SDP 'connection' attribute replaced with new 'dtls-connection' attribute.</t>
                 <t>- IANA Considerations added.</t>
                 <t>- E-mail regarding 'dtls-connection-id' attribute added as Annex.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-holmberg-mmusic-sdp-dtls-01
-			<list style="symbols">
+            <list style="symbols">
                 <t>- draft-ietf-mmusic version of draft submitted.</t>
                 <t>- Draft file name change (sdp-dtls -> dtls-sdp) due to collision with another expired draft.</t>
                 <t>- Clarify that if ufrag in offer is unchanged, it must be unchanged in associated answer.</t>
                 <t>- SIP Considerations section added.</t>
                 <t>- Section about multiple SDP fingerprint attributes added.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
         <t>Changes from draft-holmberg-mmusic-sdp-dtls-00
-			<list style="symbols">
+            <list style="symbols">
                 <t>- Editorial changes and clarifications.</t>
-			</list>
-		</t>		
+            </list>
+        </t>
 
-	</section>
+    </section>
 </middle>
 
 <back>
     <references title="Normative References">
-		<?rfc include="reference.RFC.2119"?>
+        <?rfc include="reference.RFC.2119"?>
         <?rfc include="reference.RFC.3261"?>
-		<?rfc include="reference.RFC.3264"?>
+        <?rfc include="reference.RFC.3264"?>
         <?rfc include="reference.RFC.4145"?>
         <?rfc include="reference.RFC.4566"?>
         <?rfc include="reference.RFC.4572"?>
@@ -962,13 +763,12 @@ NEW TEXT:
         <?rfc include="reference.RFC.5245"?>
         <?rfc include="reference.RFC.5763"?>
         <?rfc include="reference.RFC.7345"?>
-    </references>    
+    </references>
     <references title="Informative References">
         <?rfc include="reference.RFC.5576"?>
-		<?rfc include="reference.RFC.6083"?>
+        <?rfc include="reference.RFC.6083"?>
         <?rfc include="reference.I-D.draft-ietf-mmusic-sdp-mux-attributes-12"?>
         <?rfc include="reference.I-D.draft-ietf-mmusic-sdp-bundle-negotiation-25"?>
-    </references>    
-
+    </references>
 </back>
 </rfc>


### PR DESCRIPTION
This is a fairly major update to change the document from dtls-connection to dtls-association-id.
- This modifies handling of the 'setup' attribute to either be set to 'actpass' for offers establishing new DTLS associations or be set to currently negotiated role (this is based on the comments from the last face-to-face).
- Clarifies ICE  and transport considerations.
- Clarifies multiple fingerprint handling
- Removes Old/New text for RFC changes and lists only new text with update summary.
