### PR TITLE
	Clarify what "setup" attributes can/should be set in subsequent offers.

### DIFF
--- a/draft-ietf-mmusic-dtls-sdp.xml
+++ b/draft-ietf-mmusic-dtls-sdp.xml
@@ -416,7 +416,10 @@
                 offerer MUST insert an SDP 'dtls-id' attribute with the previously assigned value in the offer.
                 In addition, the offerer MUST insert an SDP 'setup' attribute with a value that does
                 not change the previously negotiated DTLS roles, and one or more SDP 'fingerprint' attributes with
-                values that do not change the previously sent fingerprints, in the offer.
+                values that do not change the previously sent fingerprints, in the offer. The value of the 'setup'
+                attribute SHOULD be set to 'actpass', in order to allow the answerer to establish a new DTLS
+                association with a different role, but MAY be set to the current negotiated role ('active' or
+                'passive').
             </t>
             <t>
                 NOTE: When a new DTLS association is being established, each endpoint needs to be prepared to receive


### PR DESCRIPTION
... If the same DTLS association is being re-used.

Related JSEP issue: https://github.com/rtcweb-wg/jsep/issues/448